### PR TITLE
[STOCK] 주식 캔들 차트 조회 API

### DIFF
--- a/src/main/java/app/xray/stock/stock_service/adapter/in/web/StockQueryController.java
+++ b/src/main/java/app/xray/stock/stock_service/adapter/in/web/StockQueryController.java
@@ -3,7 +3,6 @@ package app.xray.stock.stock_service.adapter.in.web;
 import app.xray.stock.stock_service.adapter.in.web.dto.StockCandlesResponse;
 import app.xray.stock.stock_service.application.port.in.QueryStockCandlesUseCase;
 import app.xray.stock.stock_service.application.port.vo.StockCandleSearchConditionQuery;
-import app.xray.stock.stock_service.common.type.CandleInterval;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 

--- a/src/main/java/app/xray/stock/stock_service/adapter/in/web/StockQueryController.java
+++ b/src/main/java/app/xray/stock/stock_service/adapter/in/web/StockQueryController.java
@@ -18,12 +18,12 @@ public class StockQueryController {
 
     @GetMapping("/{stockId}/candles")
     public StockCandlesResponse getCandles(
-            @PathVariable String stockId,
-            @RequestParam CandleInterval interval,
-            @RequestParam Instant start,
-            @RequestParam Instant end) {
-        return queryStockCandlesUseCase.queryCandles(StockCandleSearchConditionQuery.withCondition(
-                stockId, interval, start, end));
+            @PathVariable("stockId") String stockId,
+            @RequestParam(required = false) String interval,
+            @RequestParam(required = false) Instant start,
+            @RequestParam(required = false) Instant end) {
+        return queryStockCandlesUseCase.queryCandles(StockCandleSearchConditionQuery
+                .withCondition(stockId, interval, start, end));
     }
 
 

--- a/src/main/java/app/xray/stock/stock_service/adapter/in/web/StockQueryController.java
+++ b/src/main/java/app/xray/stock/stock_service/adapter/in/web/StockQueryController.java
@@ -1,0 +1,30 @@
+package app.xray.stock.stock_service.adapter.in.web;
+
+import app.xray.stock.stock_service.adapter.in.web.dto.StockCandlesResponse;
+import app.xray.stock.stock_service.application.port.in.QueryStockCandlesUseCase;
+import app.xray.stock.stock_service.application.port.vo.StockCandleSearchConditionQuery;
+import app.xray.stock.stock_service.common.type.CandleInterval;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.Instant;
+
+@RestController
+@RequestMapping("/api/v1/stocks")
+@RequiredArgsConstructor
+public class StockQueryController {
+
+    private final QueryStockCandlesUseCase queryStockCandlesUseCase;
+
+    @GetMapping("/{stockId}/candles")
+    public StockCandlesResponse getCandles(
+            @PathVariable String stockId,
+            @RequestParam CandleInterval interval,
+            @RequestParam Instant start,
+            @RequestParam Instant end) {
+        return queryStockCandlesUseCase.queryCandles(StockCandleSearchConditionQuery.withCondition(
+                stockId, interval, start, end));
+    }
+
+
+}

--- a/src/main/java/app/xray/stock/stock_service/adapter/in/web/dto/StockCandlesResponse.java
+++ b/src/main/java/app/xray/stock/stock_service/adapter/in/web/dto/StockCandlesResponse.java
@@ -1,0 +1,34 @@
+package app.xray.stock.stock_service.adapter.in.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class StockCandlesResponse {
+
+    private String symbol;
+    private String interval;
+    private List<CandleData> candles;
+
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    static class CandleData {
+        private Instant at;
+        private float open;
+        private float high;
+        private float low;
+        private float close;
+        private long volume;
+    }
+}

--- a/src/main/java/app/xray/stock/stock_service/adapter/in/web/dto/StockCandlesResponse.java
+++ b/src/main/java/app/xray/stock/stock_service/adapter/in/web/dto/StockCandlesResponse.java
@@ -1,6 +1,6 @@
 package app.xray.stock.stock_service.adapter.in.web.dto;
 
-import app.xray.stock.stock_service.common.type.CandleInterval;
+import app.xray.stock.stock_service.common.type.CandleIntervalType;
 import app.xray.stock.stock_service.domain.vo.Candle;
 import app.xray.stock.stock_service.domain.vo.TimeRange;
 import lombok.AllArgsConstructor;
@@ -22,7 +22,7 @@ public class StockCandlesResponse {
     private String interval;
     private List<CandleData> candles;
 
-    public static StockCandlesResponse of(String stockId, CandleInterval interval, List<Candle> candles) {
+    public static StockCandlesResponse of(String stockId, CandleIntervalType interval, List<Candle> candles) {
         StockCandlesResponse response = new StockCandlesResponse();
         response.stockId = stockId;
         response.interval = interval.getValue();

--- a/src/main/java/app/xray/stock/stock_service/adapter/in/web/dto/StockCandlesResponse.java
+++ b/src/main/java/app/xray/stock/stock_service/adapter/in/web/dto/StockCandlesResponse.java
@@ -1,5 +1,8 @@
 package app.xray.stock.stock_service.adapter.in.web.dto;
 
+import app.xray.stock.stock_service.common.type.CandleInterval;
+import app.xray.stock.stock_service.domain.vo.Candle;
+import app.xray.stock.stock_service.domain.vo.TimeRange;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -7,6 +10,7 @@ import lombok.Setter;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @Setter
@@ -14,21 +18,32 @@ import java.util.List;
 @AllArgsConstructor
 public class StockCandlesResponse {
 
-    private String symbol;
+    private String stockId;
     private String interval;
     private List<CandleData> candles;
 
+    public static StockCandlesResponse of(String stockId, CandleInterval interval, List<Candle> candles) {
+        StockCandlesResponse response = new StockCandlesResponse();
+        response.stockId = stockId;
+        response.interval = interval.getValue();
+        response.candles = candles.stream().map(CandleData::from).collect(Collectors.toList());
+        return response;
+    }
 
-    @Getter
-    @Setter
-    @NoArgsConstructor
-    @AllArgsConstructor
-    static class CandleData {
-        private Instant at;
-        private float open;
-        private float high;
-        private float low;
-        private float close;
-        private long volume;
+
+    record CandleData(Instant at, Double open, Double high, Double low, Double close, Long volume) {
+        public static CandleData from(Candle candle) {
+            return new CandleData(
+                    pickAt(candle.getTimeRange()),
+                    candle.getOpen(),
+                    candle.getHigh(),
+                    candle.getLow(),
+                    candle.getClose(),
+                    candle.getVolume());
+        }
+
+        private static Instant pickAt(TimeRange range) {
+            return range.start(); // 범위 중 시작 시간으로 결정함
+        }
     }
 }

--- a/src/main/java/app/xray/stock/stock_service/adapter/out/persistance/MongoTradeTickCommandAdapter.java
+++ b/src/main/java/app/xray/stock/stock_service/adapter/out/persistance/MongoTradeTickCommandAdapter.java
@@ -3,21 +3,21 @@ package app.xray.stock.stock_service.adapter.out.persistance;
 import app.xray.stock.stock_service.application.port.out.SaveTradeTickDataPort;
 import app.xray.stock.stock_service.domain.TradeTick;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.stereotype.Repository;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
 public class MongoTradeTickCommandAdapter implements SaveTradeTickDataPort {
 
-    private final MongoTradeTickRepository mongoTradeTickRepository;
+    private final MongoTemplate mongoTemplate;
 
     @Override
     public List<TradeTick> saveAll(List<TradeTick> tradeTicks) {
-        if (tradeTicks.isEmpty()) {
-            return List.of();
-        }
-        return mongoTradeTickRepository.saveAll(tradeTicks);
+        if (tradeTicks == null || tradeTicks.isEmpty()) return List.of();
+        return new ArrayList<>(mongoTemplate.insert(tradeTicks, TradeTick.class));
     }
 }

--- a/src/main/java/app/xray/stock/stock_service/adapter/out/persistance/MongoTradeTickQueryAdapter.java
+++ b/src/main/java/app/xray/stock/stock_service/adapter/out/persistance/MongoTradeTickQueryAdapter.java
@@ -5,6 +5,8 @@ import app.xray.stock.stock_service.domain.TradeTick;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -16,5 +18,10 @@ public class MongoTradeTickQueryAdapter implements LoadTradeTickDataPort {
     @Override
     public Optional<TradeTick> loadLastTradeTickDataBy(String stockId) {
         return mongoTradeTickRepository.findTopByStockIdOrderByTickAtDesc(stockId);
+    }
+
+    @Override
+    public List<TradeTick> loadTradeTicksDataByRange(String stockId, Instant start, Instant end) {
+        return mongoTradeTickRepository.findAllByStockIdAndTickAtBetweenOrderByTickAtDesc(stockId, start, end);
     }
 }

--- a/src/main/java/app/xray/stock/stock_service/adapter/out/persistance/MongoTradeTickRepository.java
+++ b/src/main/java/app/xray/stock/stock_service/adapter/out/persistance/MongoTradeTickRepository.java
@@ -4,11 +4,15 @@ import app.xray.stock.stock_service.domain.TradeTick;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface MongoTradeTickRepository extends MongoRepository<TradeTick, String> {
 
     Optional<TradeTick> findTopByStockIdOrderByTickAtDesc(String stockId);
+
+    List<TradeTick> findAllByStockIdAndTickAtBetweenOrderByTickAtDesc(String stockId, Instant start, Instant end);
 
 }

--- a/src/main/java/app/xray/stock/stock_service/application/port/in/QueryStockCandlesUseCase.java
+++ b/src/main/java/app/xray/stock/stock_service/application/port/in/QueryStockCandlesUseCase.java
@@ -1,0 +1,10 @@
+package app.xray.stock.stock_service.application.port.in;
+
+import app.xray.stock.stock_service.adapter.in.web.dto.StockCandlesResponse;
+import app.xray.stock.stock_service.application.port.vo.StockCandleSearchConditionQuery;
+
+public interface QueryStockCandlesUseCase {
+
+    StockCandlesResponse queryCandles(StockCandleSearchConditionQuery query);
+
+}

--- a/src/main/java/app/xray/stock/stock_service/application/port/out/LoadTradeTickDataPort.java
+++ b/src/main/java/app/xray/stock/stock_service/application/port/out/LoadTradeTickDataPort.java
@@ -2,9 +2,13 @@ package app.xray.stock.stock_service.application.port.out;
 
 import app.xray.stock.stock_service.domain.TradeTick;
 
+import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 
 public interface LoadTradeTickDataPort {
 
     Optional<TradeTick> loadLastTradeTickDataBy(String stockId);
+
+    List<TradeTick> loadTradeTicksDataByRange(String stockId, Instant start, Instant end);
 }

--- a/src/main/java/app/xray/stock/stock_service/application/port/vo/StockCandleSearchConditionQuery.java
+++ b/src/main/java/app/xray/stock/stock_service/application/port/vo/StockCandleSearchConditionQuery.java
@@ -1,0 +1,58 @@
+package app.xray.stock.stock_service.application.port.vo;
+
+import app.xray.stock.stock_service.common.type.CandleInterval;
+import app.xray.stock.stock_service.common.validation.NoBlankSpace;
+import app.xray.stock.stock_service.common.validation.SelfValidating;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Objects;
+
+@Getter
+public class StockCandleSearchConditionQuery extends SelfValidating<StockCandleSearchConditionQuery> {
+
+    static final CandleInterval DEFAULT_CANDLE_INTERVAL = CandleInterval.ONE_MIN;
+    static final Duration DEFAULT_TIME_GAP = Duration.of(1, ChronoUnit.HOURS);
+
+    @NotNull(message = "stockId must not be null.")
+    @NoBlankSpace(message = "stockId must not be contained blank space")
+    private String stockId;
+    private CandleInterval interval;
+    private Instant start;
+    private Instant end;
+
+    public static StockCandleSearchConditionQuery withCondition(String stockId, CandleInterval interval, Instant start, Instant end) {
+        StockCandleSearchConditionQuery query = new StockCandleSearchConditionQuery();
+        query.stockId = stockId;
+        query.interval = intervalOrDefault(interval);
+        query.end = endOrDefault(end);
+        query.start = startOrDefaultAfterInitEnd(start, query.end);
+
+        query.validateSelf();
+        return query;
+    }
+
+    private static CandleInterval intervalOrDefault(CandleInterval interval) {
+        return Objects.requireNonNullElse(interval, DEFAULT_CANDLE_INTERVAL);
+    }
+
+    private static Instant endOrDefault(Instant end) {
+        return Objects.requireNonNullElse(end, Instant.now());
+    }
+
+    private static Instant startOrDefaultAfterInitEnd(Instant start, Instant end) {
+        if (start == null) {
+            if (end == null) {
+                throw new IllegalArgumentException("Both start and end cannot be null.");
+            }
+            return end.minus(DEFAULT_TIME_GAP);
+        }
+        if (!start.isBefore(end)) {
+            throw new IllegalArgumentException("Start time must be before end time.");
+        }
+        return start;
+    }
+}

--- a/src/main/java/app/xray/stock/stock_service/application/port/vo/StockCandleSearchConditionQuery.java
+++ b/src/main/java/app/xray/stock/stock_service/application/port/vo/StockCandleSearchConditionQuery.java
@@ -1,6 +1,6 @@
 package app.xray.stock.stock_service.application.port.vo;
 
-import app.xray.stock.stock_service.common.type.CandleInterval;
+import app.xray.stock.stock_service.common.type.CandleIntervalType;
 import app.xray.stock.stock_service.common.validation.NoBlankSpace;
 import app.xray.stock.stock_service.common.validation.SelfValidating;
 import jakarta.validation.constraints.NotNull;
@@ -10,50 +10,52 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 
 @Getter
 public class StockCandleSearchConditionQuery extends SelfValidating<StockCandleSearchConditionQuery> {
 
-    static final CandleInterval DEFAULT_CANDLE_INTERVAL = CandleInterval.ONE_MIN;
+    static final CandleIntervalType DEFAULT_CANDLE_INTERVAL = CandleIntervalType.ONE_MIN;
     static final Duration DEFAULT_TIME_GAP = Duration.of(1, ChronoUnit.HOURS);
 
     @NotNull(message = "stockId must not be null.")
     @NoBlankSpace(message = "stockId must not be contained blank space")
     private String stockId;
-    private CandleInterval interval;
+    private CandleIntervalType interval;
     private Instant start;
     private Instant end;
 
-    public static StockCandleSearchConditionQuery withCondition(String stockId, String interval, Instant start,
-                                                                Instant end) {
+    public static StockCandleSearchConditionQuery withCondition(String stockId, String interval,
+                                                                Instant start, Instant end) {
         StockCandleSearchConditionQuery query = new StockCandleSearchConditionQuery();
         query.stockId = stockId;
-        query.interval = intervalOrDefault(CandleInterval.convertOrDefaultNull(interval));
-        query.end = endOrDefault(end);
-        query.start = startOrDefaultAfterInitEnd(start, query.end);
+        query.interval = intervalOrDefault(CandleIntervalType.convertOrDefaultNull(interval));
+        query.end = endOrDefaultWithTruncating(end);
+        query.start = startOrDefaultAfterInitEndWithTruncating(start, query.end);
 
         query.validateSelf();
         return query;
     }
 
-    private static CandleInterval intervalOrDefault(CandleInterval interval) {
+    private static CandleIntervalType intervalOrDefault(CandleIntervalType interval) {
         return Objects.requireNonNullElse(interval, DEFAULT_CANDLE_INTERVAL);
     }
 
-    private static Instant endOrDefault(Instant end) {
-        return Objects.requireNonNullElse(end, Instant.now());
+    private static Instant endOrDefaultWithTruncating(Instant end) {
+        return Objects.requireNonNullElse(end, Instant.now()).truncatedTo(TimeUnit.SECONDS.toChronoUnit());
     }
 
-    private static Instant startOrDefaultAfterInitEnd(Instant start, Instant end) {
+    private static Instant startOrDefaultAfterInitEndWithTruncating(
+            Instant start, Instant truncatedEnd) {
         if (start == null) {
-            if (end == null) {
+            if (truncatedEnd == null) {
                 throw new IllegalArgumentException("Both start and end cannot be null.");
             }
-            return end.minus(DEFAULT_TIME_GAP);
+            return truncatedEnd.minus(DEFAULT_TIME_GAP);
         }
-        if (!start.isBefore(end)) {
+        if (!start.isBefore(truncatedEnd)) {
             throw new IllegalArgumentException("Start time must be before end time.");
         }
-        return start;
+        return start.truncatedTo(TimeUnit.SECONDS.toChronoUnit());
     }
 }

--- a/src/main/java/app/xray/stock/stock_service/application/port/vo/StockCandleSearchConditionQuery.java
+++ b/src/main/java/app/xray/stock/stock_service/application/port/vo/StockCandleSearchConditionQuery.java
@@ -24,10 +24,11 @@ public class StockCandleSearchConditionQuery extends SelfValidating<StockCandleS
     private Instant start;
     private Instant end;
 
-    public static StockCandleSearchConditionQuery withCondition(String stockId, CandleInterval interval, Instant start, Instant end) {
+    public static StockCandleSearchConditionQuery withCondition(String stockId, String interval, Instant start,
+                                                                Instant end) {
         StockCandleSearchConditionQuery query = new StockCandleSearchConditionQuery();
         query.stockId = stockId;
-        query.interval = intervalOrDefault(interval);
+        query.interval = intervalOrDefault(CandleInterval.convertOrDefaultNull(interval));
         query.end = endOrDefault(end);
         query.start = startOrDefaultAfterInitEnd(start, query.end);
 

--- a/src/main/java/app/xray/stock/stock_service/application/service/StockCandlesQueryService.java
+++ b/src/main/java/app/xray/stock/stock_service/application/service/StockCandlesQueryService.java
@@ -2,12 +2,51 @@ package app.xray.stock.stock_service.application.service;
 
 import app.xray.stock.stock_service.adapter.in.web.dto.StockCandlesResponse;
 import app.xray.stock.stock_service.application.port.in.QueryStockCandlesUseCase;
+import app.xray.stock.stock_service.application.port.out.LoadStockDataPort;
+import app.xray.stock.stock_service.application.port.out.LoadTradeTickDataPort;
 import app.xray.stock.stock_service.application.port.vo.StockCandleSearchConditionQuery;
+import app.xray.stock.stock_service.common.exception.NotFoundException;
+import app.xray.stock.stock_service.common.type.CandleInterval;
+import app.xray.stock.stock_service.domain.Stock;
+import app.xray.stock.stock_service.domain.TradeTick;
+import app.xray.stock.stock_service.domain.TradeTicksCandleConverter;
+import app.xray.stock.stock_service.domain.vo.Candle;
+import app.xray.stock.stock_service.domain.vo.TimeRange;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
 public class StockCandlesQueryService implements QueryStockCandlesUseCase {
+
+    private final LoadStockDataPort loadStockDataPort;
+    private final LoadTradeTickDataPort loadTradeTickDataPort;
 
     @Override
     public StockCandlesResponse queryCandles(StockCandleSearchConditionQuery query) {
-        return null; //  TODO
+
+        // 주식 기본 정보 조회
+        String stockId = query.getStockId();
+        CandleInterval interval = query.getInterval();
+        loadStockDataPort.findOneById(stockId).orElseThrow(() -> NotFoundException.of(Stock.class, stockId))
+                .assertEnabled();
+
+        // 주식 차트 정보 조회
+        Instant start = query.getStart();
+        Instant end = query.getEnd();
+
+        List<TradeTick> tradeTicks = loadTradeTickDataPort.loadTradeTicksDataByRange(stockId, start, end);
+
+        TradeTicksCandleConverter converter = TradeTicksCandleConverter.forConverting(
+                TimeRange.of(start, end), interval, tradeTicks);
+        converter.aggregate();
+        List<Candle> candles = converter.getCandles();
+
+        return StockCandlesResponse.of(stockId, interval, candles);
     }
 }

--- a/src/main/java/app/xray/stock/stock_service/application/service/StockCandlesQueryService.java
+++ b/src/main/java/app/xray/stock/stock_service/application/service/StockCandlesQueryService.java
@@ -6,7 +6,7 @@ import app.xray.stock.stock_service.application.port.out.LoadStockDataPort;
 import app.xray.stock.stock_service.application.port.out.LoadTradeTickDataPort;
 import app.xray.stock.stock_service.application.port.vo.StockCandleSearchConditionQuery;
 import app.xray.stock.stock_service.common.exception.NotFoundException;
-import app.xray.stock.stock_service.common.type.CandleInterval;
+import app.xray.stock.stock_service.common.type.CandleIntervalType;
 import app.xray.stock.stock_service.domain.Stock;
 import app.xray.stock.stock_service.domain.TradeTick;
 import app.xray.stock.stock_service.domain.TradeTicksCandleConverter;
@@ -32,7 +32,7 @@ public class StockCandlesQueryService implements QueryStockCandlesUseCase {
 
         // 주식 기본 정보 조회
         String stockId = query.getStockId();
-        CandleInterval interval = query.getInterval();
+        CandleIntervalType interval = query.getInterval();
         loadStockDataPort.findOneById(stockId).orElseThrow(() -> NotFoundException.of(Stock.class, stockId))
                 .assertEnabled();
 
@@ -44,7 +44,7 @@ public class StockCandlesQueryService implements QueryStockCandlesUseCase {
 
         TradeTicksCandleConverter converter = TradeTicksCandleConverter.forConverting(
                 TimeRange.of(start, end), interval, tradeTicks);
-        converter.aggregate();
+        converter.aggregate(false);
         List<Candle> candles = converter.getCandles();
 
         return StockCandlesResponse.of(stockId, interval, candles);

--- a/src/main/java/app/xray/stock/stock_service/application/service/StockCandlesQueryService.java
+++ b/src/main/java/app/xray/stock/stock_service/application/service/StockCandlesQueryService.java
@@ -33,8 +33,8 @@ public class StockCandlesQueryService implements QueryStockCandlesUseCase {
         // 주식 기본 정보 조회
         String stockId = query.getStockId();
         CandleIntervalType interval = query.getInterval();
-        loadStockDataPort.findOneById(stockId).orElseThrow(() -> NotFoundException.of(Stock.class, stockId))
-                .assertEnabled();
+        Stock stock = loadStockDataPort.findOneById(stockId).orElseThrow(() -> NotFoundException.of(Stock.class, stockId));
+        stock.assertEnabled();
 
         // 주식 차트 정보 조회
         Instant start = query.getStart();
@@ -42,8 +42,7 @@ public class StockCandlesQueryService implements QueryStockCandlesUseCase {
 
         List<TradeTick> tradeTicks = loadTradeTickDataPort.loadTradeTicksDataByRange(stockId, start, end);
 
-        TradeTicksCandleConverter converter = TradeTicksCandleConverter.forConverting(
-                TimeRange.of(start, end), interval, tradeTicks);
+        TradeTicksCandleConverter converter = TradeTicksCandleConverter.forConverting(stock.getMarketType(), TimeRange.of(start, end), interval, tradeTicks);
         converter.aggregate(false);
         List<Candle> candles = converter.getCandles();
 

--- a/src/main/java/app/xray/stock/stock_service/application/service/StockCandlesQueryService.java
+++ b/src/main/java/app/xray/stock/stock_service/application/service/StockCandlesQueryService.java
@@ -1,0 +1,13 @@
+package app.xray.stock.stock_service.application.service;
+
+import app.xray.stock.stock_service.adapter.in.web.dto.StockCandlesResponse;
+import app.xray.stock.stock_service.application.port.in.QueryStockCandlesUseCase;
+import app.xray.stock.stock_service.application.port.vo.StockCandleSearchConditionQuery;
+
+public class StockCandlesQueryService implements QueryStockCandlesUseCase {
+
+    @Override
+    public StockCandlesResponse queryCandles(StockCandleSearchConditionQuery query) {
+        return null; //  TODO
+    }
+}

--- a/src/main/java/app/xray/stock/stock_service/application/service/TradeTickCommandService.java
+++ b/src/main/java/app/xray/stock/stock_service/application/service/TradeTickCommandService.java
@@ -1,13 +1,12 @@
 package app.xray.stock.stock_service.application.service;
 
 import app.xray.stock.stock_service.adapter.out.external.dto.TradeTickDataResponse;
-import app.xray.stock.stock_service.adapter.out.persistance.MongoTradeTickRepository;
 import app.xray.stock.stock_service.application.port.in.CollectTradeTickDataUseCase;
 import app.xray.stock.stock_service.application.port.out.LoadTradeTickDataPort;
 import app.xray.stock.stock_service.application.port.out.SaveTradeTickDataPort;
 import app.xray.stock.stock_service.application.port.out.StockGeneratorClient;
 import app.xray.stock.stock_service.application.port.vo.CollectStockCommand;
-import app.xray.stock.stock_service.common.exception.NoTradeTickCollectedException;
+import app.xray.stock.stock_service.application.service.exception.NoTradeTickCollectedException;
 import app.xray.stock.stock_service.domain.Stock;
 import app.xray.stock.stock_service.domain.TradeTick;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/app/xray/stock/stock_service/application/service/TradeTickCommandService.java
+++ b/src/main/java/app/xray/stock/stock_service/application/service/TradeTickCommandService.java
@@ -44,9 +44,10 @@ public class TradeTickCommandService implements CollectTradeTickDataUseCase {
                     start, end);
 
             // 저장 처리 진행
-            List<TradeTick> tradeTicks = TradeTick.fromResponses(stock.getId(), rangeTradeTicksResponse);
-            saveTradeTickDataPort.saveAll(tradeTicks);
+            saveTradeTickDataPort.saveAll(TradeTick.fromResponses(
+                    stock.getId(), rangeTradeTicksResponse));
             // TODO lastCollectedAt 정보 저장하기
+
         }
     }
 }

--- a/src/main/java/app/xray/stock/stock_service/application/service/exception/NoTradeTickCollectedException.java
+++ b/src/main/java/app/xray/stock/stock_service/application/service/exception/NoTradeTickCollectedException.java
@@ -1,4 +1,4 @@
-package app.xray.stock.stock_service.common.exception;
+package app.xray.stock.stock_service.application.service.exception;
 
 import java.time.Instant;
 

--- a/src/main/java/app/xray/stock/stock_service/common/exception/NotFoundException.java
+++ b/src/main/java/app/xray/stock/stock_service/common/exception/NotFoundException.java
@@ -1,0 +1,27 @@
+package app.xray.stock.stock_service.common.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * 주어진 리소스를 찾을 수 없을 때 사용하는 예외.
+ */
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class NotFoundException extends RuntimeException {
+
+    private NotFoundException(String message) {
+        super(message);
+    }
+
+    public static NotFoundException of(String message) {
+        return new NotFoundException(message);
+    }
+
+    public static NotFoundException of(String resource, Object identifier) {
+        return new NotFoundException(resource + " not found. (identifier = " + identifier + ")");
+    }
+
+    public static NotFoundException of(Class<?> clazz, Object identifier) {
+        return new NotFoundException(clazz.getSimpleName() + " not found. (identifier = " + identifier + ")");
+    }
+}

--- a/src/main/java/app/xray/stock/stock_service/common/type/CandleInterval.java
+++ b/src/main/java/app/xray/stock/stock_service/common/type/CandleInterval.java
@@ -2,15 +2,22 @@ package app.xray.stock.stock_service.common.type;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.time.Duration;
 import java.util.Arrays;
 
 @RequiredArgsConstructor
 public enum CandleInterval {
-    ONE_MIN("1m"), FIVE_MIN("5m"), ONE_DAY("1d"), ONE_WEEK("1w");
+    ONE_MIN("1m", Duration.ofMinutes(1)),
+    FIVE_MIN("5m", Duration.ofMinutes(5)),
+    ONE_DAY("1d", Duration.ofDays(1)),
+    ONE_WEEK("1w", Duration.ofDays(7));
 
     private final String value;
+    @Getter
+    private final Duration duration;
 
     @JsonValue
     public String getValue() {
@@ -18,8 +25,8 @@ public enum CandleInterval {
     }
 
     @JsonCreator
-    public static CandleInterval from(String value) {
+    public static CandleInterval convertOrDefaultNull(String value) {
         return Arrays.stream(values()).filter(v -> v.value.equalsIgnoreCase(value))
-                .findFirst().orElseThrow(() -> new IllegalArgumentException("Invalid CandleInternal: " + value));
+                .findFirst().orElse(null);
     }
 }

--- a/src/main/java/app/xray/stock/stock_service/common/type/CandleInterval.java
+++ b/src/main/java/app/xray/stock/stock_service/common/type/CandleInterval.java
@@ -1,0 +1,25 @@
+package app.xray.stock.stock_service.common.type;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+
+@RequiredArgsConstructor
+public enum CandleInterval {
+    ONE_MIN("1m"), FIVE_MIN("5m"), ONE_DAY("1d"), ONE_WEEK("1w");
+
+    private final String value;
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @JsonCreator
+    public static CandleInterval from(String value) {
+        return Arrays.stream(values()).filter(v -> v.value.equalsIgnoreCase(value))
+                .findFirst().orElseThrow(() -> new IllegalArgumentException("Invalid CandleInternal: " + value));
+    }
+}

--- a/src/main/java/app/xray/stock/stock_service/common/type/CandleIntervalType.java
+++ b/src/main/java/app/xray/stock/stock_service/common/type/CandleIntervalType.java
@@ -11,15 +11,18 @@ import java.util.Arrays;
 @RequiredArgsConstructor
 public enum CandleIntervalType {
 
-    FIVE_SEC("5s", Duration.ofSeconds(5)),
-    ONE_MIN("1m", Duration.ofMinutes(1)),
-    FIVE_MIN("5m", Duration.ofMinutes(5)),
-    ONE_DAY("1d", Duration.ofDays(1)),
-    ONE_WEEK("1w", Duration.ofDays(7));
+
+    FIVE_SEC("5s", Duration.ofSeconds(5), Duration.ofHours(1)),
+    ONE_MIN("1m", Duration.ofMinutes(1), Duration.ofDays(7)),
+    FIVE_MIN("5m", Duration.ofMinutes(5), Duration.ofDays(60)),
+    ONE_DAY("1d", Duration.ofDays(1), Duration.ofDays(365 * 5)),
+    ONE_WEEK("1w", Duration.ofDays(7), Duration.ofDays(365 * 10));
 
     private final String value;
     @Getter
     private final Duration duration;
+    @Getter
+    private final Duration maxRange;
 
     @JsonValue
     public String getValue() {
@@ -30,5 +33,9 @@ public enum CandleIntervalType {
     public static CandleIntervalType convertOrDefaultNull(String value) {
         return Arrays.stream(values()).filter(v -> v.value.equalsIgnoreCase(value))
                 .findFirst().orElse(null);
+    }
+
+    public Duration getMinRange() {
+        return duration.multipliedBy(2);
     }
 }

--- a/src/main/java/app/xray/stock/stock_service/common/type/CandleIntervalType.java
+++ b/src/main/java/app/xray/stock/stock_service/common/type/CandleIntervalType.java
@@ -9,7 +9,9 @@ import java.time.Duration;
 import java.util.Arrays;
 
 @RequiredArgsConstructor
-public enum CandleInterval {
+public enum CandleIntervalType {
+
+    FIVE_SEC("5s", Duration.ofSeconds(5)),
     ONE_MIN("1m", Duration.ofMinutes(1)),
     FIVE_MIN("5m", Duration.ofMinutes(5)),
     ONE_DAY("1d", Duration.ofDays(1)),
@@ -25,7 +27,7 @@ public enum CandleInterval {
     }
 
     @JsonCreator
-    public static CandleInterval convertOrDefaultNull(String value) {
+    public static CandleIntervalType convertOrDefaultNull(String value) {
         return Arrays.stream(values()).filter(v -> v.value.equalsIgnoreCase(value))
                 .findFirst().orElse(null);
     }

--- a/src/main/java/app/xray/stock/stock_service/domain/Stock.java
+++ b/src/main/java/app/xray/stock/stock_service/domain/Stock.java
@@ -1,10 +1,11 @@
 package app.xray.stock.stock_service.domain;
 
+import app.xray.stock.stock_service.domain.exception.StockDisabledException;
 import app.xray.stock.stock_service.common.validation.NoBlankSpace;
 import app.xray.stock.stock_service.common.validation.SelfValidating;
+import app.xray.stock.stock_service.domain.exception.StockNotStartedException;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -53,22 +54,26 @@ public class Stock extends SelfValidating<Stock> {
     }
 
     public void start() {
-        if (!enable) {
-            throw new IllegalStateException(); // FIXME custom exception
-        }
+        assertEnabled();
         startedAt = Instant.now();
         endedAt = null;
     }
 
     public void stop() {
         if (startedAt == null) {
-            throw new IllegalStateException(); // FIXME custom exception
+            throw new StockNotStartedException(id);
         }
         endedAt = Instant.now();
     }
 
     public void enable(boolean enable) {
         this.enable = enable;
+    }
+
+    public void assertEnabled() {
+        if (enable == null || !enable) {
+            throw new StockDisabledException(id);
+        }
     }
 
     /**

--- a/src/main/java/app/xray/stock/stock_service/domain/Stock.java
+++ b/src/main/java/app/xray/stock/stock_service/domain/Stock.java
@@ -14,6 +14,7 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.time.Instant;
+import java.time.ZoneId;
 import java.util.Locale;
 
 @Document(collection = "stocks")
@@ -85,10 +86,11 @@ public class Stock extends SelfValidating<Stock> {
     @Getter
     @RequiredArgsConstructor
     public enum MarketType {
-        KOSPI(Locale.KOREA, 0),
-        NASDAQ(Locale.US, 2);
+        KOSPI(Locale.KOREA, ZoneId.of("Asia/Seoul"), 0),
+        NASDAQ(Locale.US, ZoneId.of("America/New_York"), 2);
 
         private final Locale locale;
+        private final ZoneId zoneId;
         private final int decimalPlaces;
     }
 }

--- a/src/main/java/app/xray/stock/stock_service/domain/TradeTick.java
+++ b/src/main/java/app/xray/stock/stock_service/domain/TradeTick.java
@@ -18,7 +18,7 @@ import java.time.Instant;
 import java.util.List;
 
 @Document(collection = "trade_ticks")
-@TimeSeries(timeField = "tickAt", metaField = "stockId", granularity = Granularity.SECONDS)
+@TimeSeries(timeField = "tickAt", metaField = "stockId", granularity = Granularity.SECONDS, expireAfter = "30d")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TradeTick extends SelfValidating<TradeTick> {

--- a/src/main/java/app/xray/stock/stock_service/domain/TradeTicksCandleConverter.java
+++ b/src/main/java/app/xray/stock/stock_service/domain/TradeTicksCandleConverter.java
@@ -1,6 +1,7 @@
 package app.xray.stock.stock_service.domain;
 
 import app.xray.stock.stock_service.common.type.CandleIntervalType;
+import app.xray.stock.stock_service.domain.Stock.MarketType;
 import app.xray.stock.stock_service.domain.vo.Candle;
 import app.xray.stock.stock_service.domain.vo.TimeRange;
 import org.springframework.util.Assert;
@@ -11,18 +12,24 @@ import java.util.List;
 
 public class TradeTicksCandleConverter {
 
+    private MarketType marketType;
     private TimeRange timeRange;
     private CandleIntervalType interval;
     private List<TradeTick> tradeTicks;
     private List<Candle> candles;
 
     public static TradeTicksCandleConverter forConverting(
-            TimeRange timeRange, CandleIntervalType interval, List<TradeTick> tradeTicks) {
+            MarketType marketType,
+            TimeRange timeRange,
+            CandleIntervalType interval,
+            List<TradeTick> tradeTicks) {
+        Assert.notNull(marketType, "marketType must not be null");
         Assert.notNull(timeRange, "timeRange must not be null");
         Assert.notNull(interval, "interval must not be null");
         Assert.notEmpty(tradeTicks, "tradeTicks must not be empty");
 
         TradeTicksCandleConverter converter = new TradeTicksCandleConverter();
+        converter.marketType = marketType;
         converter.timeRange = timeRange;
         converter.interval = interval;
         converter.tradeTicks = tradeTicks;
@@ -32,7 +39,7 @@ public class TradeTicksCandleConverter {
 
 
     public void aggregate(boolean includeEmptySlots) {
-        List<TimeRange> ranges = timeRange.makeIntervals(interval);
+        List<TimeRange> ranges = timeRange.makeIntervalsWithZone(interval, marketType.getZoneId());
         List<Candle> result = new ArrayList<>();
 
         for (TimeRange range : ranges) {

--- a/src/main/java/app/xray/stock/stock_service/domain/TradeTicksCandleConverter.java
+++ b/src/main/java/app/xray/stock/stock_service/domain/TradeTicksCandleConverter.java
@@ -1,0 +1,69 @@
+package app.xray.stock.stock_service.domain;
+
+import app.xray.stock.stock_service.common.type.CandleInterval;
+import app.xray.stock.stock_service.domain.vo.Candle;
+import app.xray.stock.stock_service.domain.vo.TimeRange;
+import org.springframework.util.Assert;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+public class TradeTicksCandleConverter {
+
+    private TimeRange timeRange;
+
+    private CandleInterval interval;
+    private List<TradeTick> tradeTicks;
+    private List<Candle> candles;
+
+    public static TradeTicksCandleConverter forConverting(
+            TimeRange timeRange, CandleInterval interval, List<TradeTick> tradeTicks) {
+        Assert.notNull(timeRange, "timeRange must not be null");
+        Assert.notNull(interval, "interval must not be null");
+        Assert.notEmpty(tradeTicks, "tradeTicks must not be empty");
+
+        TradeTicksCandleConverter converter = new TradeTicksCandleConverter();
+        converter.timeRange = timeRange;
+        converter.interval = interval;
+        converter.tradeTicks = tradeTicks;
+
+        return converter;
+    }
+
+
+    public void aggregate() {
+        List<TimeRange> ranges = timeRange.makeIntervals(interval);
+        List<Candle> result = new ArrayList<>();
+
+        for (TimeRange range : ranges) {
+            List<TradeTick> ticksInRange = tradeTicks.stream()
+                    .filter(tick -> !tick.getTickAt().isBefore(range.start()) && tick.getTickAt().isBefore(range.end()))
+                    .sorted(Comparator.comparing(TradeTick::getTickAt))
+                    .toList();
+
+            if (ticksInRange.isEmpty()) {
+                result.add(Candle.onlyRange(range));
+                continue;
+            }
+
+            double open = ticksInRange.getFirst().getPrice();
+            double close = ticksInRange.getLast().getPrice();
+            double high = ticksInRange.stream().mapToDouble(TradeTick::getPrice).max().orElse(open);
+            double low = ticksInRange.stream().mapToDouble(TradeTick::getPrice).min().orElse(open);
+            long volume = ticksInRange.stream().mapToLong(TradeTick::getVolume).sum();
+
+            result.add(Candle.create(range, open, high, low, close, volume));
+        }
+
+        this.candles = result;
+    }
+
+
+    public List<Candle> getCandles() {
+        if (candles == null) {
+            throw new IllegalStateException(); // 메세지
+        }
+        return candles;
+    }
+}

--- a/src/main/java/app/xray/stock/stock_service/domain/TradeTicksCandleConverter.java
+++ b/src/main/java/app/xray/stock/stock_service/domain/TradeTicksCandleConverter.java
@@ -1,6 +1,6 @@
 package app.xray.stock.stock_service.domain;
 
-import app.xray.stock.stock_service.common.type.CandleInterval;
+import app.xray.stock.stock_service.common.type.CandleIntervalType;
 import app.xray.stock.stock_service.domain.vo.Candle;
 import app.xray.stock.stock_service.domain.vo.TimeRange;
 import org.springframework.util.Assert;
@@ -12,13 +12,12 @@ import java.util.List;
 public class TradeTicksCandleConverter {
 
     private TimeRange timeRange;
-
-    private CandleInterval interval;
+    private CandleIntervalType interval;
     private List<TradeTick> tradeTicks;
     private List<Candle> candles;
 
     public static TradeTicksCandleConverter forConverting(
-            TimeRange timeRange, CandleInterval interval, List<TradeTick> tradeTicks) {
+            TimeRange timeRange, CandleIntervalType interval, List<TradeTick> tradeTicks) {
         Assert.notNull(timeRange, "timeRange must not be null");
         Assert.notNull(interval, "interval must not be null");
         Assert.notEmpty(tradeTicks, "tradeTicks must not be empty");
@@ -32,7 +31,7 @@ public class TradeTicksCandleConverter {
     }
 
 
-    public void aggregate() {
+    public void aggregate(boolean includeEmptySlots) {
         List<TimeRange> ranges = timeRange.makeIntervals(interval);
         List<Candle> result = new ArrayList<>();
 
@@ -43,7 +42,9 @@ public class TradeTicksCandleConverter {
                     .toList();
 
             if (ticksInRange.isEmpty()) {
-                result.add(Candle.onlyRange(range));
+                if (includeEmptySlots) {
+                    result.add(Candle.onlyRange(range));
+                }
                 continue;
             }
 

--- a/src/main/java/app/xray/stock/stock_service/domain/exception/StockDisabledException.java
+++ b/src/main/java/app/xray/stock/stock_service/domain/exception/StockDisabledException.java
@@ -1,0 +1,7 @@
+package app.xray.stock.stock_service.domain.exception;
+
+public class StockDisabledException extends IllegalStateException {
+    public StockDisabledException(String stockId) {
+        super("Stock is not enabled: " + stockId);
+    }
+}

--- a/src/main/java/app/xray/stock/stock_service/domain/exception/StockNotStartedException.java
+++ b/src/main/java/app/xray/stock/stock_service/domain/exception/StockNotStartedException.java
@@ -1,0 +1,10 @@
+package app.xray.stock.stock_service.domain.exception;
+
+/**
+ * Stock 이 시작되지 않았는데 stop()이 호출된 경우 발생.
+ */
+public class StockNotStartedException extends IllegalStateException {
+    public StockNotStartedException(String stockId) {
+        super("Cannot stop stock because it was not started. (stockId = " + stockId + ")");
+    }
+}

--- a/src/main/java/app/xray/stock/stock_service/domain/vo/Candle.java
+++ b/src/main/java/app/xray/stock/stock_service/domain/vo/Candle.java
@@ -1,0 +1,35 @@
+package app.xray.stock.stock_service.domain.vo;
+
+import app.xray.stock.stock_service.common.validation.SelfValidating;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class Candle extends SelfValidating<Candle> {
+
+    @NotNull
+    private final TimeRange timeRange;
+    private final Double open;
+    private final Double high;
+    private final Double low;
+    private final Double close;
+    private final Long volume;
+
+    private Candle(TimeRange timeRange, Double open, Double high, Double low, Double close, Long volume) {
+        this.timeRange = timeRange;
+        this.open = open;
+        this.high = high;
+        this.low = low;
+        this.close = close;
+        this.volume = volume;
+        validateSelf();
+    }
+
+    public static Candle create(TimeRange range, double open, double high, double low, double close, long volume) {
+        return new Candle(range, open, high, low, close, volume);
+    }
+
+    public static Candle onlyRange(TimeRange range) {
+        return new Candle(range, null, null, null, null, null);
+    }
+}

--- a/src/main/java/app/xray/stock/stock_service/domain/vo/TimeRange.java
+++ b/src/main/java/app/xray/stock/stock_service/domain/vo/TimeRange.java
@@ -1,0 +1,32 @@
+package app.xray.stock.stock_service.domain.vo;
+
+import app.xray.stock.stock_service.common.type.CandleInterval;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+public record TimeRange(Instant start, Instant end) {
+
+    public static TimeRange of(Instant start, Instant end) {
+        return new TimeRange(start, end);
+    }
+
+    public List<TimeRange> makeIntervals(CandleInterval interval) {
+        List<TimeRange> ranges = new ArrayList<>();
+
+        Instant cursor = start;
+        while (cursor.isBefore(end)) {
+            Instant next = cursor.plus(interval.getDuration());
+            if (next.isAfter(end)) {
+                ranges.add(TimeRange.of(cursor, end)); // 마지막 자투리
+                break;
+            } else {
+                ranges.add(TimeRange.of(cursor, next));
+                cursor = next;
+            }
+        }
+
+        return ranges;
+    }
+}

--- a/src/main/java/app/xray/stock/stock_service/domain/vo/TimeRange.java
+++ b/src/main/java/app/xray/stock/stock_service/domain/vo/TimeRange.java
@@ -1,6 +1,6 @@
 package app.xray.stock.stock_service.domain.vo;
 
-import app.xray.stock.stock_service.common.type.CandleInterval;
+import app.xray.stock.stock_service.common.type.CandleIntervalType;
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -12,7 +12,7 @@ public record TimeRange(Instant start, Instant end) {
         return new TimeRange(start, end);
     }
 
-    public List<TimeRange> makeIntervals(CandleInterval interval) {
+    public List<TimeRange> makeIntervals(CandleIntervalType interval) {
         List<TimeRange> ranges = new ArrayList<>();
 
         Instant cursor = start;

--- a/src/main/java/app/xray/stock/stock_service/domain/vo/TimeRange.java
+++ b/src/main/java/app/xray/stock/stock_service/domain/vo/TimeRange.java
@@ -2,31 +2,88 @@ package app.xray.stock.stock_service.domain.vo;
 
 import app.xray.stock.stock_service.common.type.CandleIntervalType;
 
+import java.time.Duration;
 import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * 지정된 시간 범위(start ~ end)를 주어진 캔들 간격과 타임존 기준으로 일정 구간(TimeRange)들로 분할한다.
+ */
 public record TimeRange(Instant start, Instant end) {
 
     public static TimeRange of(Instant start, Instant end) {
         return new TimeRange(start, end);
     }
 
-    public List<TimeRange> makeIntervals(CandleIntervalType interval) {
+    /**
+     * 타임존 기준으로 캔들 간격에 맞게 정렬된 구간 리스트를 생성한다.
+     *
+     * @param interval 캔들 구간 (예: 5초, 1분, 1시간, 1일 등)
+     * @param zoneId   타임존 (예: Asia/Seoul)
+     * @return 정렬된 TimeRange 목록
+     */
+    public List<TimeRange> makeIntervalsWithZone(CandleIntervalType interval, ZoneId zoneId) {
         List<TimeRange> ranges = new ArrayList<>();
 
-        Instant cursor = start;
-        while (cursor.isBefore(end)) {
-            Instant next = cursor.plus(interval.getDuration());
-            if (next.isAfter(end)) {
-                ranges.add(TimeRange.of(cursor, end)); // 마지막 자투리
-                break;
-            } else {
-                ranges.add(TimeRange.of(cursor, next));
-                cursor = next;
-            }
+        ZonedDateTime zonedStart = start.atZone(zoneId);
+        ZonedDateTime zonedEnd = end.atZone(zoneId);
+
+        // 캔들 간격 시작점 정렬
+        ZonedDateTime cursor = alignToInterval(zonedStart, interval);
+
+        // start 이전 구간이면 다음 캔들로 이동
+        if (cursor.isBefore(zonedStart)) {
+            cursor = cursor.plus(interval.getDuration());
+        }
+
+        while (cursor.isBefore(zonedEnd)) {
+            ZonedDateTime next = cursor.plus(interval.getDuration());
+            Instant rangeStart = cursor.toInstant();
+            Instant rangeEnd = next.isAfter(zonedEnd) ? end : next.toInstant();
+            ranges.add(TimeRange.of(rangeStart, rangeEnd));
+            cursor = next;
         }
 
         return ranges;
+    }
+
+    /**
+     * 주어진 ZonedDateTime 을 캔들 구간에 맞게 정렬된 기준 시점으로 맞춘다.
+     * <pre>
+     * 정렬 기준:
+     * - 60초 미만: 분 단위로 truncate 후, 초 정렬 (ex: 5초 → 00, 05, 10 ...)
+     * - 1시간 미만: 시 단위로 truncate 후, 분 정렬 (ex: 5분 → 00, 05, 10 ...)
+     * - 1일 미만: 시 정렬
+     * - 1일 이상: 자정 정렬
+     * </pre>
+     */
+    private ZonedDateTime alignToInterval(ZonedDateTime time, CandleIntervalType interval) {
+        Duration duration = interval.getDuration();
+        long durationSeconds = duration.getSeconds();
+
+        if (durationSeconds < 60) {
+            // 초 단위 정렬
+            int alignedSecond = (time.getSecond() / (int) durationSeconds) * (int) durationSeconds;
+            return time.truncatedTo(ChronoUnit.MINUTES)
+                    .withSecond(alignedSecond)
+                    .withNano(0);
+        } else if (durationSeconds < 3600) {
+            // 분 단위 정렬
+            int minutes = (time.getMinute() / (int) (durationSeconds / 60)) * (int) (durationSeconds / 60);
+            return time.truncatedTo(ChronoUnit.HOURS)
+                    .withMinute(minutes)
+                    .withSecond(0)
+                    .withNano(0);
+        } else if (durationSeconds < 86400) {
+            // 시간 단위 정렬
+            return time.truncatedTo(ChronoUnit.HOURS);
+        } else {
+            // 일 단위 정렬
+            return time.toLocalDate().atStartOfDay(time.getZone());
+        }
     }
 }

--- a/src/test/java/app/xray/stock/stock_service/domain/TimeRangeTest.java
+++ b/src/test/java/app/xray/stock/stock_service/domain/TimeRangeTest.java
@@ -1,0 +1,89 @@
+package app.xray.stock.stock_service.domain;
+
+import app.xray.stock.stock_service.common.type.CandleIntervalType;
+import app.xray.stock.stock_service.domain.vo.TimeRange;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.Arguments;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TimeRangeTest {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    static Stream<Arguments> provideIntervalTestCases() {
+        return Stream.of(
+                Arguments.of(
+                        "5초 단위",
+                        CandleIntervalType.FIVE_SEC,
+                        Instant.parse("2025-06-20T14:59:56Z"),
+                        Instant.parse("2025-06-20T15:00:07Z"),
+                        2
+                ),
+                Arguments.of(
+                        "1분 단위",
+                        CandleIntervalType.ONE_MIN,
+                        Instant.parse("2025-06-20T14:59:45Z"),
+                        Instant.parse("2025-06-20T15:01:10Z"),
+                        2
+                ),
+                Arguments.of(
+                        "5분 단위",
+                        CandleIntervalType.FIVE_MIN,
+                        Instant.parse("2025-06-20T14:57:12Z"),
+                        Instant.parse("2025-06-20T15:03:30Z"),
+                        1
+                ),
+                Arguments.of(
+                        "1일 단위",
+                        CandleIntervalType.ONE_DAY,
+                        Instant.parse("2025-06-20T14:00:00Z"),
+                        Instant.parse("2025-06-22T14:00:00Z"),
+                        2
+                ),
+                Arguments.of(
+                        "1주 단위",
+                        CandleIntervalType.ONE_WEEK,
+                        Instant.parse("2025-06-01T15:00:00Z"),
+                        Instant.parse("2025-06-22T14:59:59Z"),
+                        3
+                )
+        );
+    }
+
+    @ParameterizedTest(name = "[{index}] {0}")
+    @MethodSource("provideIntervalTestCases")
+    void testAlignedIntervals(
+            String name,
+            CandleIntervalType interval,
+            Instant start,
+            Instant end,
+            int expectedSize
+    ) {
+        // when
+        TimeRange range = TimeRange.of(start, end);
+        List<TimeRange> intervals = range.makeIntervalsWithZone(interval, KST);
+
+        // then
+        assertThat(intervals).hasSize(expectedSize);
+
+        // 구간 길이 확인
+        Duration intervalDuration = interval.getDuration();
+        for (int i = 0; i < intervals.size(); i++) {
+            TimeRange r = intervals.get(i);
+            Duration actual = Duration.between(r.start(), r.end());
+            if (i < intervals.size() - 1) {
+                assertThat(actual).isEqualTo(intervalDuration);
+            } else {
+                assertThat(actual).isLessThanOrEqualTo(intervalDuration);
+            }
+        }
+    }
+}

--- a/src/test/java/app/xray/stock/stock_service/domain/TradeTicksCandleConverterTest.java
+++ b/src/test/java/app/xray/stock/stock_service/domain/TradeTicksCandleConverterTest.java
@@ -1,0 +1,208 @@
+package app.xray.stock.stock_service.domain;
+
+import app.xray.stock.stock_service.common.type.CandleIntervalType;
+import app.xray.stock.stock_service.domain.Stock.MarketType;
+import app.xray.stock.stock_service.domain.vo.Candle;
+import app.xray.stock.stock_service.domain.vo.TimeRange;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TradeTicksCandleConverterTest {
+
+    @Test
+    void itShouldAggregateTradeTicksIntoOneMinuteCandlesCorrectly() {
+        // given
+        Instant start = Instant.parse("2025-06-20T00:00:00Z"); // KST 09:00
+        Instant end = Instant.parse("2025-06-20T00:03:00Z");   // KST 09:03
+
+        TimeRange range = TimeRange.of(start, end);
+
+        List<TradeTick> ticks = List.of(
+                TradeTick.create("STK1", 100.0, 0.0, 10, Instant.parse("2025-06-20T00:00:10Z")),
+                TradeTick.create("STK1", 105.0, 0.0, 5, Instant.parse("2025-06-20T00:00:50Z")),
+                TradeTick.create("STK1", 103.0, 0.0, 20, Instant.parse("2025-06-20T00:01:05Z")),
+                TradeTick.create("STK1", 102.0, 0.0, 10, Instant.parse("2025-06-20T00:01:45Z")),
+                TradeTick.create("STK1", 110.0, 0.0, 15, Instant.parse("2025-06-20T00:02:30Z"))
+        );
+
+        TradeTicksCandleConverter converter = TradeTicksCandleConverter.forConverting(
+                MarketType.KOSPI,
+                range,
+                CandleIntervalType.ONE_MIN,
+                ticks
+        );
+
+        // when
+        converter.aggregate(true);
+        List<Candle> candles = converter.getCandles();
+
+        // then
+        assertThat(candles).hasSize(3);
+
+        // 첫 번째 캔들 (00:00 ~ 00:01)
+        Candle c1 = candles.get(0);
+        assertThat(c1.getOpen()).isEqualTo(100.0);
+        assertThat(c1.getClose()).isEqualTo(105.0);
+        assertThat(c1.getHigh()).isEqualTo(105.0);
+        assertThat(c1.getLow()).isEqualTo(100.0);
+        assertThat(c1.getVolume()).isEqualTo(15L);
+
+        // 두 번째 캔들 (00:01 ~ 00:02)
+        Candle c2 = candles.get(1);
+        assertThat(c2.getOpen()).isEqualTo(103.0);
+        assertThat(c2.getClose()).isEqualTo(102.0);
+        assertThat(c2.getHigh()).isEqualTo(103.0);
+        assertThat(c2.getLow()).isEqualTo(102.0);
+        assertThat(c2.getVolume()).isEqualTo(30L);
+
+        // 세 번째 캔들 (00:02 ~ 00:03)
+        Candle c3 = candles.get(2);
+        assertThat(c3.getOpen()).isEqualTo(110.0);
+        assertThat(c3.getClose()).isEqualTo(110.0);
+        assertThat(c3.getHigh()).isEqualTo(110.0);
+        assertThat(c3.getLow()).isEqualTo(110.0);
+        assertThat(c3.getVolume()).isEqualTo(15L);
+    }
+
+    static Stream<Arguments> provideTestCases() {
+        return Stream.of(
+                Arguments.of(
+                        "정상 캔들 생성 - 1분 단위",
+                        CandleIntervalType.ONE_MIN,
+                        Instant.parse("2025-06-20T00:00:00Z"),
+                        Instant.parse("2025-06-20T00:03:00Z"),
+                        List.of(
+                                TradeTick.create("STK1", 100.0, 0.0, 10, Instant.parse("2025-06-20T00:00:10Z")),
+                                TradeTick.create("STK1", 105.0, 0.0, 5, Instant.parse("2025-06-20T00:00:50Z")),
+                                TradeTick.create("STK1", 103.0, 0.0, 20, Instant.parse("2025-06-20T00:01:05Z")),
+                                TradeTick.create("STK1", 102.0, 0.0, 10, Instant.parse("2025-06-20T00:01:45Z")),
+                                TradeTick.create("STK1", 110.0, 0.0, 15, Instant.parse("2025-06-20T00:02:30Z"))
+                        ),
+                        true,
+                        3
+                ),
+                Arguments.of(
+                        "빈 구간 포함 - 1분 단위",
+                        CandleIntervalType.ONE_MIN,
+                        Instant.parse("2025-06-20T00:00:00Z"),
+                        Instant.parse("2025-06-20T00:03:00Z"),
+                        List.of(
+                                TradeTick.create("STK1", 100.0, 0.0, 10, Instant.parse("2025-06-20T00:00:10Z")),
+                                TradeTick.create("STK1", 110.0, 0.0, 10, Instant.parse("2025-06-20T00:02:10Z"))
+                        ),
+                        true,
+                        3
+                ),
+                Arguments.of(
+                        "빈 구간 제외 - 1분 단위",
+                        CandleIntervalType.ONE_MIN,
+                        Instant.parse("2025-06-20T00:00:00Z"),
+                        Instant.parse("2025-06-20T00:03:00Z"),
+                        List.of(
+                                TradeTick.create("STK1", 100.0, 0.0, 10, Instant.parse("2025-06-20T00:00:10Z")),
+                                TradeTick.create("STK1", 110.0, 0.0, 10, Instant.parse("2025-06-20T00:02:10Z"))
+                        ),
+                        false,
+                        2
+                ),
+                Arguments.of(
+                        "정렬되지 않은 입력 - 1분 단위",
+                        CandleIntervalType.ONE_MIN,
+                        Instant.parse("2025-06-20T00:00:00Z"),
+                        Instant.parse("2025-06-20T00:02:00Z"),
+                        List.of(
+                                TradeTick.create("STK1", 102.0, 0.0, 10, Instant.parse("2025-06-20T00:01:45Z")),
+                                TradeTick.create("STK1", 103.0, 0.0, 20, Instant.parse("2025-06-20T00:01:05Z")),
+                                TradeTick.create("STK1", 105.0, 0.0, 5, Instant.parse("2025-06-20T00:00:50Z")),
+                                TradeTick.create("STK1", 100.0, 0.0, 10, Instant.parse("2025-06-20T00:00:10Z"))
+                        ),
+                        true,
+                        2
+                ),
+                Arguments.of(
+                        "start 이전 tick 무시",
+                        CandleIntervalType.ONE_MIN,
+                        Instant.parse("2025-06-20T00:00:00Z"),
+                        Instant.parse("2025-06-20T00:01:00Z"),
+                        List.of(
+                                TradeTick.create("STK1", 90.0, 0.0, 10, Instant.parse("2025-06-19T23:59:59Z")),
+                                TradeTick.create("STK1", 100.0, 0.0, 20, Instant.parse("2025-06-20T00:00:10Z"))
+                        ),
+                        true,
+                        1
+                ),
+                Arguments.of(
+                        "5분 단위 캔들 - 전체 구간 포함",
+                        CandleIntervalType.FIVE_MIN,
+                        Instant.parse("2025-06-20T00:00:00Z"),  // 09:00
+                        Instant.parse("2025-06-20T00:15:00Z"),  // 09:15
+                        List.of(
+                                TradeTick.create("STK1", 101.0, 0.0, 10, Instant.parse("2025-06-20T00:01:00Z")), // 첫 구간
+                                TradeTick.create("STK1", 103.0, 0.0, 20, Instant.parse("2025-06-20T00:07:00Z")), // 두번째 구간
+                                TradeTick.create("STK1", 105.0, 0.0, 15, Instant.parse("2025-06-20T00:14:00Z"))  // 세번째 구간
+                        ),
+                        true,
+                        3
+                ),
+                Arguments.of(
+                        "1일 단위 캔들 - 빈 날짜 포함",
+                        CandleIntervalType.ONE_DAY,
+                        Instant.parse("2025-06-20T00:00:00Z"),  // 6/20 09:00 KST
+                        Instant.parse("2025-06-23T00:00:00Z"),  // 6/23 09:00 KST
+                        List.of(
+                                TradeTick.create("STK1", 100.0, 0.0, 5, Instant.parse("2025-06-20T01:00:00Z")),
+                                TradeTick.create("STK1", 110.0, 0.0, 10, Instant.parse("2025-06-21T05:00:00Z"))
+                                // 6/22에는 없음
+                        ),
+                        true,
+                        3
+                )
+        );
+    }
+
+    @ParameterizedTest(name = "[{index}] {0}")
+    @MethodSource("provideTestCases")
+    void itShouldGenerateCandlesCorrectlyWithinGivenRange(
+            String name,
+            CandleIntervalType interval,
+            Instant start,
+            Instant end,
+            List<TradeTick> ticks,
+            boolean includeEmptySlots,
+            int expectedCandleCount
+    ) {
+        // given
+        TimeRange range = TimeRange.of(start, end);
+        TradeTicksCandleConverter converter = TradeTicksCandleConverter.forConverting(
+                MarketType.KOSPI,
+                range,
+                interval,
+                ticks
+        );
+
+        // when
+        converter.aggregate(includeEmptySlots);
+        List<Candle> candles = converter.getCandles();
+
+        // then
+        assertThat(candles).hasSize(expectedCandleCount);
+
+        // 모든 candle 의 시간 범위는 range 안에 있고,
+        candles.forEach(c -> {
+            assertThat(c.getTimeRange().start()).isBetween(start, end.minusNanos(1));
+            assertThat(c.getTimeRange().end()).isBetween(start.plusNanos(1), end);
+        });
+
+        // 모든 candle 은 오름차순 정렬된 상태
+        assertThat(candles).isSortedAccordingTo(Comparator.comparing(c -> c.getTimeRange().start()));
+    }
+}


### PR DESCRIPTION
## 주요 변경 사항

- 주식의 캔들(candle) 차트 데이터를 조회할 수 있는 API를 신규로 구현했습니다.
- 조회 가능한 정보: 시가(open), 종가(close), 고가(high), 저가(low), 거래량(volume) 등
- 요청 파라미터: 주식 종목 코드, 기간(시작일/종료일), 차트 타입(일/주/월봉 등)
- 서비스, 컨트롤러, DTO 등 관련 클래스 신규 생성 및 테스트 코드 추가

## 테스트

- 정상 케이스 및 엣지 케이스에 대한 단위 테스트 작성 및 통과 확인
- 예외 상황(잘못된 파라미터, 데이터 없음 등)에 대한 응답 처리 확인
