### PR TITLE
[STOCK] 주식 목록 조회 API

### DIFF
--- a/src/main/java/app/xray/stock/stock_service/adapter/in/job/CollectStockTradeTickScheduler.java
+++ b/src/main/java/app/xray/stock/stock_service/adapter/in/job/CollectStockTradeTickScheduler.java
@@ -9,6 +9,7 @@ import lombok.extern.log4j.Log4j2;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import java.time.Instant;
 import java.util.List;
 
 @Log4j2
@@ -22,8 +23,9 @@ public class CollectStockTradeTickScheduler {
     @Scheduled(fixedRate = 5000)
     public void collect() {
         log.info("[CollectStockTradeTickScheduler.collect] START");
-        List<Stock> stocks = loadCollectEnableStocksUseCase.loadAll();
-        collectTradeTickDataUseCase.collectAndSave(CollectStockCommand.from(stocks));
+        Instant now = Instant.now();
+        List<Stock> stocks = loadCollectEnableStocksUseCase.loadAll(now);
+        collectTradeTickDataUseCase.collectAndSave(CollectStockCommand.of(stocks, now));
         log.info("[CollectStockTradeTickScheduler.collect] END");
     }
 }

--- a/src/main/java/app/xray/stock/stock_service/adapter/in/web/StockQueryController.java
+++ b/src/main/java/app/xray/stock/stock_service/adapter/in/web/StockQueryController.java
@@ -1,12 +1,14 @@
 package app.xray.stock.stock_service.adapter.in.web;
 
 import app.xray.stock.stock_service.adapter.in.web.dto.StockCandlesResponse;
+import app.xray.stock.stock_service.adapter.in.web.dto.StockListResponse;
 import app.xray.stock.stock_service.application.port.in.QueryStockCandlesUseCase;
 import app.xray.stock.stock_service.application.port.vo.StockCandleSearchConditionQuery;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.Instant;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/stocks")
@@ -14,6 +16,13 @@ import java.time.Instant;
 public class StockQueryController {
 
     private final QueryStockCandlesUseCase queryStockCandlesUseCase;
+
+    @GetMapping
+    public StockListResponse getStocks(
+            @RequestParam("") String sort
+    ) {
+        return new StockListResponse(List.of());
+    }
 
     @GetMapping("/{stockId}/candles")
     public StockCandlesResponse getCandles(
@@ -24,6 +33,4 @@ public class StockQueryController {
         return queryStockCandlesUseCase.queryCandles(StockCandleSearchConditionQuery
                 .withCondition(stockId, interval, start, end));
     }
-
-
 }

--- a/src/main/java/app/xray/stock/stock_service/adapter/in/web/StockQueryController.java
+++ b/src/main/java/app/xray/stock/stock_service/adapter/in/web/StockQueryController.java
@@ -1,9 +1,12 @@
 package app.xray.stock.stock_service.adapter.in.web;
 
+import app.xray.stock.stock_service.application.port.in.QueryStockListUseCase;
 import app.xray.stock.stock_service.adapter.in.web.dto.StockCandlesResponse;
 import app.xray.stock.stock_service.adapter.in.web.dto.StockListResponse;
 import app.xray.stock.stock_service.application.port.in.QueryStockCandlesUseCase;
 import app.xray.stock.stock_service.application.port.vo.StockCandleSearchConditionQuery;
+import app.xray.stock.stock_service.application.port.vo.StockListQuery;
+import app.xray.stock.stock_service.domain.Stock;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -15,13 +18,13 @@ import java.util.List;
 @RequiredArgsConstructor
 public class StockQueryController {
 
+    private final QueryStockListUseCase queryStockListUseCase;
     private final QueryStockCandlesUseCase queryStockCandlesUseCase;
 
     @GetMapping
-    public StockListResponse getStocks(
-            @RequestParam("") String sort
-    ) {
-        return new StockListResponse(List.of());
+    public StockListResponse getStocks(@RequestParam("marketCode") String marketCode) {
+        List<Stock> stocks = queryStockListUseCase.queryStockTopRoiRank(StockListQuery.from(marketCode));
+        return StockListResponse.from(stocks);
     }
 
     @GetMapping("/{stockId}/candles")

--- a/src/main/java/app/xray/stock/stock_service/adapter/in/web/dto/StockListResponse.java
+++ b/src/main/java/app/xray/stock/stock_service/adapter/in/web/dto/StockListResponse.java
@@ -1,10 +1,41 @@
 package app.xray.stock.stock_service.adapter.in.web.dto;
 
+import app.xray.stock.stock_service.domain.Stock;
+import app.xray.stock.stock_service.domain.TradeTick;
+import app.xray.stock.stock_service.domain.vo.Candle;
+
 import java.util.List;
 
 public record StockListResponse(
         List<StockItem> stocks
 ) {
+    public static StockListResponse from(List<Stock> stocks) {
+        List<StockItem> items = new java.util.ArrayList<>();
+
+        for (int i = 0; i < stocks.size(); i++) {
+            Stock stock = stocks.get(i);
+            TradeTick tick = stock.getCurrentTradeTick();
+            Candle candle = stock.getPreviousCandle();
+
+            double currentPrice = tick != null ? tick.getPrice() : 0.0;
+            Double close = candle != null ? candle.getClose() : null;
+            int changePrice = (close != null) ? (int) (currentPrice - close) : 0;
+            double changeRate = tick != null ? tick.getChangeRate() : 0.0;
+            boolean isLimitUp = stock.getMarketType().isLimitUp(changeRate);
+
+            items.add(new StockItem(
+                    i + 1, // rank는 정렬된 순서대로 1부터
+                    stock.getName(),
+                    stock.getSymbol(),
+                    (int) currentPrice,
+                    changePrice,
+                    changeRate,
+                    isLimitUp
+            ));
+        }
+        return new StockListResponse(items);
+    }
+
     public record StockItem(
             int rank,
             String name,

--- a/src/main/java/app/xray/stock/stock_service/adapter/in/web/dto/StockListResponse.java
+++ b/src/main/java/app/xray/stock/stock_service/adapter/in/web/dto/StockListResponse.java
@@ -1,0 +1,17 @@
+package app.xray.stock.stock_service.adapter.in.web.dto;
+
+import java.util.List;
+
+public record StockListResponse(
+        List<StockItem> stocks
+) {
+    public record StockItem(
+            int rank,
+            String name,
+            String symbol,
+            int currentPrice,
+            int changePrice,
+            double changeRate,
+            boolean isLimitUp // TODO 구현 - 개념 파악 필요
+    ) {}
+}

--- a/src/main/java/app/xray/stock/stock_service/application/handler/TradeTickSavedEventHandler.java
+++ b/src/main/java/app/xray/stock/stock_service/application/handler/TradeTickSavedEventHandler.java
@@ -19,8 +19,10 @@ public class TradeTickSavedEventHandler {
     @Async
     @EventListener
     public void handleTradeTickSavedEvent(TradeTickSavedEvent event) {
-        log.info("[TradeTickSavedEventHandler.handleTradeTickSavedEvent] stockId={}, timeRange.start={}, timeRange" +
-                        ".end={}",
+        log.info("[TradeTickSavedEventHandler.handleTradeTickSavedEvent] " +
+                        "stockId={}, " +
+                        "timeRange.start={}, " +
+                        "timeRange.end={}",
                 event.stockId(), event.start(), event.end());
         service.updateTradingInfo(event.stockId());
     }

--- a/src/main/java/app/xray/stock/stock_service/application/handler/TradeTickSavedEventHandler.java
+++ b/src/main/java/app/xray/stock/stock_service/application/handler/TradeTickSavedEventHandler.java
@@ -1,0 +1,28 @@
+package app.xray.stock.stock_service.application.handler;
+
+
+import app.xray.stock.stock_service.application.service.StockCommandService;
+import app.xray.stock.stock_service.common.event.TradeTickSavedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Log4j2
+@Component
+@RequiredArgsConstructor
+public class TradeTickSavedEventHandler {
+
+    private final StockCommandService service;
+
+    @Async
+    @EventListener
+    public void handleTradeTickSavedEvent(TradeTickSavedEvent event) {
+        log.info("[TradeTickSavedEventHandler.handleTradeTickSavedEvent] stockId={}, timeRange.start={}, timeRange" +
+                        ".end={}",
+                event.stockId(), event.start(), event.end());
+        service.updateTradingInfo(event.stockId());
+    }
+
+}

--- a/src/main/java/app/xray/stock/stock_service/application/port/in/LoadCollectEnableStocksUseCase.java
+++ b/src/main/java/app/xray/stock/stock_service/application/port/in/LoadCollectEnableStocksUseCase.java
@@ -2,9 +2,10 @@ package app.xray.stock.stock_service.application.port.in;
 
 import app.xray.stock.stock_service.domain.Stock;
 
+import java.time.Instant;
 import java.util.List;
 
 public interface LoadCollectEnableStocksUseCase {
 
-    List<Stock> loadAll();
+    List<Stock> loadAll(Instant now);
 }

--- a/src/main/java/app/xray/stock/stock_service/application/port/in/QueryStockListUseCase.java
+++ b/src/main/java/app/xray/stock/stock_service/application/port/in/QueryStockListUseCase.java
@@ -1,0 +1,11 @@
+package app.xray.stock.stock_service.application.port.in;
+
+import app.xray.stock.stock_service.application.port.vo.StockListQuery;
+import app.xray.stock.stock_service.domain.Stock;
+
+import java.util.List;
+
+public interface QueryStockListUseCase {
+
+    List<Stock> queryStockTopRoiRank(StockListQuery from);
+}

--- a/src/main/java/app/xray/stock/stock_service/application/port/out/LoadStockListDataPort.java
+++ b/src/main/java/app/xray/stock/stock_service/application/port/out/LoadStockListDataPort.java
@@ -1,9 +1,13 @@
 package app.xray.stock.stock_service.application.port.out;
 
 import app.xray.stock.stock_service.domain.Stock;
+import org.springframework.data.mongodb.repository.Query;
 
 import java.util.List;
 
 public interface LoadStockListDataPort {
     List<Stock> findAllByEnableIsTrue();
+
+    @Query("{ '_id': { $regex: ?0 }, 'enable': true }") // TODO 어뎁터 리팩토링
+    List<Stock> findByMarketIdPrefix(String marketIdPrefixRegex);
 }

--- a/src/main/java/app/xray/stock/stock_service/application/port/vo/CollectStockCommand.java
+++ b/src/main/java/app/xray/stock/stock_service/application/port/vo/CollectStockCommand.java
@@ -3,22 +3,27 @@ package app.xray.stock.stock_service.application.port.vo;
 import app.xray.stock.stock_service.common.validation.SelfValidating;
 import app.xray.stock.stock_service.domain.Stock;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
+import java.time.Instant;
 import java.util.List;
 
 @Getter
 public class CollectStockCommand extends SelfValidating<CollectStockCommand> {
 
-    @NotEmpty
+    @NotNull
     private final List<Stock> stocks;
+    @NotNull
+    private final Instant at;
 
-    private CollectStockCommand(List<Stock> stocks) {
+    private CollectStockCommand(List<Stock> stocks, Instant now) {
         this.stocks = stocks;
+        this.at = now;
         validateSelf();
     }
 
-    public static CollectStockCommand from(List<Stock> stocks) {
-        return new CollectStockCommand(stocks);
+    public static CollectStockCommand of(List<Stock> stocks, Instant now) {
+        return new CollectStockCommand(stocks, now);
     }
 }

--- a/src/main/java/app/xray/stock/stock_service/application/port/vo/StockListQuery.java
+++ b/src/main/java/app/xray/stock/stock_service/application/port/vo/StockListQuery.java
@@ -1,0 +1,20 @@
+package app.xray.stock.stock_service.application.port.vo;
+
+import app.xray.stock.stock_service.common.validation.SelfValidating;
+import app.xray.stock.stock_service.domain.Stock;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class StockListQuery extends SelfValidating<StockListQuery> {
+
+    @NotNull
+    Stock.MarketType marketType;
+
+    public static StockListQuery from(String marketCode) {
+        StockListQuery query = new StockListQuery();
+        query.marketType = Stock.MarketType.valueOf(marketCode);
+        query.validateSelf();
+        return query;
+    }
+}

--- a/src/main/java/app/xray/stock/stock_service/application/service/StockCommandService.java
+++ b/src/main/java/app/xray/stock/stock_service/application/service/StockCommandService.java
@@ -4,23 +4,29 @@ import app.xray.stock.stock_service.application.port.in.SaveStockUseCase;
 import app.xray.stock.stock_service.application.port.in.StartCollectingStockUseCase;
 import app.xray.stock.stock_service.application.port.in.StopCollectingStockUseCase;
 import app.xray.stock.stock_service.application.port.out.LoadStockDataPort;
+import app.xray.stock.stock_service.application.port.out.LoadTradeTickDataPort;
 import app.xray.stock.stock_service.application.port.out.SaveStockDataPort;
 import app.xray.stock.stock_service.application.port.out.StockGeneratorClient;
 import app.xray.stock.stock_service.application.port.vo.SaveStockCommand;
 import app.xray.stock.stock_service.application.port.vo.StartCollectingStockCommand;
 import app.xray.stock.stock_service.application.port.vo.StopCollectingStockCommand;
 import app.xray.stock.stock_service.domain.Stock;
+import app.xray.stock.stock_service.domain.TradeTick;
+import app.xray.stock.stock_service.domain.vo.TimeRange;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
+import java.util.List;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class StockCommandService implements SaveStockUseCase, StartCollectingStockUseCase, StopCollectingStockUseCase {
 
     private final SaveStockDataPort saveStockDataPort;
     private final LoadStockDataPort loadStockDataPort;
+    private final LoadTradeTickDataPort loadTradeTickDataPort;
 
     private final StockGeneratorClient stockGeneratorClient;
 
@@ -41,6 +47,27 @@ public class StockCommandService implements SaveStockUseCase, StartCollectingSto
     public void stopCollecting(StopCollectingStockCommand command) {
         Stock stock = loadStockDataPort.findOneById(command.getStockId()).orElseThrow(); // FIXME custom exception
         stock.stop();
+        saveStockDataPort.save(stock);
+    }
+
+
+    public void updateTradingInfo(String stockId) {
+        Stock stock = loadStockDataPort.findOneById(stockId).orElseThrow();
+
+        TradeTick current = loadTradeTickDataPort
+                .loadLastTradeTickDataBy(stockId)
+                .orElseThrow();
+
+        stock.updateCurrentTradeTick(current);
+
+        if (stock.needsToUpdatePreviousCandle()) {
+            TimeRange range = TimeRange.ofYesterday(current.getTickAt(), stock.getMarketType().getZoneId());
+            List<TradeTick> yesterdayTicks = loadTradeTickDataPort
+                    .loadTradeTicksDataByRange(stockId, range.start(), range.end());
+
+            stock.updatePreviousCandleWith(yesterdayTicks);
+        }
+
         saveStockDataPort.save(stock);
     }
 }

--- a/src/main/java/app/xray/stock/stock_service/application/service/StockCommandService.java
+++ b/src/main/java/app/xray/stock/stock_service/application/service/StockCommandService.java
@@ -58,8 +58,6 @@ public class StockCommandService implements SaveStockUseCase, StartCollectingSto
                 .loadLastTradeTickDataBy(stockId)
                 .orElseThrow();
 
-        stock.updateCurrentTradeTick(current);
-
         if (stock.needsToUpdatePreviousCandle()) {
             TimeRange range = TimeRange.ofYesterday(current.getTickAt(), stock.getMarketType().getZoneId());
             List<TradeTick> yesterdayTicks = loadTradeTickDataPort
@@ -67,7 +65,7 @@ public class StockCommandService implements SaveStockUseCase, StartCollectingSto
 
             stock.updatePreviousCandleWith(yesterdayTicks);
         }
-
+        stock.updateCurrentTradeTick(current);
         saveStockDataPort.save(stock);
     }
 }

--- a/src/main/java/app/xray/stock/stock_service/application/service/StockQueryService.java
+++ b/src/main/java/app/xray/stock/stock_service/application/service/StockQueryService.java
@@ -1,18 +1,32 @@
 package app.xray.stock.stock_service.application.service;
 
 import app.xray.stock.stock_service.application.port.in.LoadCollectEnableStocksUseCase;
+import app.xray.stock.stock_service.application.port.in.QueryStockListUseCase;
 import app.xray.stock.stock_service.application.port.out.LoadStockListDataPort;
+import app.xray.stock.stock_service.application.port.vo.StockListQuery;
 import app.xray.stock.stock_service.domain.Stock;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.Comparator;
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-public class StockQueryService implements LoadCollectEnableStocksUseCase {
+public class StockQueryService implements QueryStockListUseCase, LoadCollectEnableStocksUseCase {
 
     private final LoadStockListDataPort loadStockListDataPort;
+
+    @Override
+    public List<Stock> queryStockTopRoiRank(StockListQuery query) {
+        return loadStockListDataPort.findByMarketIdPrefix("^" + query.getMarketType().name() + "::")
+                .stream()
+                .filter(stock -> stock.getCurrentTradeTick() != null)
+                .sorted(Comparator.comparing(
+                        (Stock s) -> s.getCurrentTradeTick().getChangeRate()
+                ).reversed())
+                .toList();
+    }
 
     @Override
     public List<Stock> loadAll() {

--- a/src/main/java/app/xray/stock/stock_service/application/service/StockQueryService.java
+++ b/src/main/java/app/xray/stock/stock_service/application/service/StockQueryService.java
@@ -8,6 +8,7 @@ import app.xray.stock.stock_service.domain.Stock;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.Instant;
 import java.util.Comparator;
 import java.util.List;
 
@@ -29,7 +30,9 @@ public class StockQueryService implements QueryStockListUseCase, LoadCollectEnab
     }
 
     @Override
-    public List<Stock> loadAll() {
-        return loadStockListDataPort.findAllByEnableIsTrue();
+    public List<Stock> loadAll(Instant now) {
+        return loadStockListDataPort.findAllByEnableIsTrue().stream()
+                .filter(each ->  each.getMarketType().isMarketOpenNow(now))
+                .toList();
     }
 }

--- a/src/main/java/app/xray/stock/stock_service/application/service/TradeTickCommandService.java
+++ b/src/main/java/app/xray/stock/stock_service/application/service/TradeTickCommandService.java
@@ -35,7 +35,7 @@ public class TradeTickCommandService implements CollectTradeTickDataUseCase {
     public void collectAndSave(CollectStockCommand command) {
         for (Stock stock : command.getStocks()) {
             Optional<TradeTick> optionalLastTradeTick = loadTradeTickDataPort.loadLastTradeTickDataBy(stock.getId());
-            Instant end = Instant.now();
+            Instant end = command.getAt();
             Instant start = optionalLastTradeTick.isEmpty() ? end.minusSeconds(5) : optionalLastTradeTick.get().getTickAt();
             List<TradeTickDataResponse> rangeTradeTicksResponse = stockGeneratorClient.getRangeTradeTicks(stock.getSymbol(), start, end);
             if (rangeTradeTicksResponse.isEmpty()) {

--- a/src/main/java/app/xray/stock/stock_service/application/service/TradeTickCommandService.java
+++ b/src/main/java/app/xray/stock/stock_service/application/service/TradeTickCommandService.java
@@ -10,7 +10,6 @@ import app.xray.stock.stock_service.application.service.exception.NoTradeTickCol
 import app.xray.stock.stock_service.common.event.TradeTickSavedEvent;
 import app.xray.stock.stock_service.domain.Stock;
 import app.xray.stock.stock_service.domain.TradeTick;
-import app.xray.stock.stock_service.domain.vo.TimeRange;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.context.ApplicationEventPublisher;

--- a/src/main/java/app/xray/stock/stock_service/common/event/TradeTickSavedEvent.java
+++ b/src/main/java/app/xray/stock/stock_service/common/event/TradeTickSavedEvent.java
@@ -1,0 +1,6 @@
+package app.xray.stock.stock_service.common.event;
+
+
+import java.time.Instant;
+
+public record TradeTickSavedEvent(String stockId, Instant start, Instant end) { }

--- a/src/main/java/app/xray/stock/stock_service/domain/Stock.java
+++ b/src/main/java/app/xray/stock/stock_service/domain/Stock.java
@@ -5,6 +5,7 @@ import app.xray.stock.stock_service.common.validation.NoBlankSpace;
 import app.xray.stock.stock_service.common.validation.SelfValidating;
 import app.xray.stock.stock_service.domain.exception.StockDisabledException;
 import app.xray.stock.stock_service.domain.exception.StockNotStartedException;
+import app.xray.stock.stock_service.domain.type.MarketType;
 import app.xray.stock.stock_service.domain.vo.Candle;
 import app.xray.stock.stock_service.domain.vo.TimeRange;
 import jakarta.validation.constraints.NotBlank;
@@ -12,13 +13,13 @@ import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-import java.time.*;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
-import java.util.Locale;
 
 @Document(collection = "stocks")
 @Getter
@@ -95,7 +96,7 @@ public class Stock extends SelfValidating<Stock> {
     public boolean needsToUpdatePreviousCandle() {
         if (previousCandle == null) return true;
 
-        ZoneId zoneId = marketType.zoneId;
+        ZoneId zoneId = marketType.getZoneId();
         LocalDate currentDate = currentTradeTick.getTickAt().atZone(zoneId).toLocalDate();
         LocalDate expectedPreviousCandleDate = getPreviousBusinessDay(currentDate);
 
@@ -105,28 +106,10 @@ public class Stock extends SelfValidating<Stock> {
 
     private LocalDate getPreviousBusinessDay(LocalDate date) {
         LocalDate d = date.minusDays(1);
-        while (isHoliday(d)) {
+        while (marketType.isHoliday(d)) {
             d = d.minusDays(1);
         }
         return d;
-    }
-
-    private boolean isHoliday(LocalDate date) {
-        return isWeekend(date) || isNationalHoliday(date);
-        // 추가로 공휴일 리스트 포함하려면 이 메서드 확장 가능
-    }
-
-    private boolean isWeekend(LocalDate date) {
-        DayOfWeek day = date.getDayOfWeek();
-        return day == DayOfWeek.SATURDAY || day == DayOfWeek.SUNDAY;
-    }
-
-    private boolean isNationalHoliday(LocalDate date) {
-        return List.of(
-                LocalDate.of(2025, 1, 1),   // 신정
-                LocalDate.of(2025, 3, 1),   // 삼일절
-                LocalDate.of(2025, 6, 6)    // 현충일 등등
-        ).contains(date);
     }
 
     public void updatePreviousCandleWith(List<TradeTick> yesterdayTicks) {
@@ -144,54 +127,6 @@ public class Stock extends SelfValidating<Stock> {
         Instant start = yesterday.atStartOfDay(zoneId).toInstant();
         Instant end = yesterday.plusDays(1).atStartOfDay(zoneId).minusNanos(1).toInstant();
         return TimeRange.of(start, end);
-    }
-
-
-    /**
-     * MarketType 는 시장 구분을 정의하는 enum 입니다.
-     * <pre>
-     * - decimalPlaces: 해당 시장에서 사용하는 기본 소숫점 자리수
-     * </pre>
-     */
-    @Getter
-    @RequiredArgsConstructor
-    public enum MarketType {
-        KOSPI(
-                Locale.KOREA,
-                ZoneId.of("Asia/Seoul"),
-                0,
-                LocalTime.of(9, 0),
-                LocalTime.of(15, 30),
-                30.0
-        ),
-        NASDAQ(
-                Locale.US,
-                ZoneId.of("America/New_York"),
-                2,
-                LocalTime.of(9, 30),
-                LocalTime.of(16, 0),
-                null
-        );
-
-        private final Locale locale;
-        private final ZoneId zoneId;
-        private final int decimalPlaces;
-        private final LocalTime marketOpenTime;
-        private final LocalTime marketCloseTime;
-        private final Double limitUpRatePercent;
-
-        public boolean isLimitUp(double changeRate) {
-            return limitUpRatePercent != null && changeRate >= (limitUpRatePercent * 0.99); // 29.7 for 30%
-        }
-
-        /**
-         * 현재 시간이 장중인지 확인 (해당 시장 기준)
-         */
-        public boolean isMarketOpenNow(Instant now) {
-            ZonedDateTime zonedNow = now.atZone(zoneId);
-            LocalTime localTime = zonedNow.toLocalTime();
-            return !localTime.isBefore(marketOpenTime) && localTime.isBefore(marketCloseTime);
-        }
     }
 }
 

--- a/src/main/java/app/xray/stock/stock_service/domain/Stock.java
+++ b/src/main/java/app/xray/stock/stock_service/domain/Stock.java
@@ -85,6 +85,11 @@ public class Stock extends SelfValidating<Stock> {
 
     public void updateCurrentTradeTick(TradeTick currentTradeTick) {
         this.currentTradeTick = currentTradeTick;
+        if (previousCandle == null || previousCandle.getClose() == null) {
+            this.currentTradeTick.clearChangeRate();
+            return;
+        }
+        this.currentTradeTick.updateChangeRate(previousCandle.getClose());
     }
 
     public boolean needsToUpdatePreviousCandle() {
@@ -156,14 +161,16 @@ public class Stock extends SelfValidating<Stock> {
                 ZoneId.of("Asia/Seoul"),
                 0,
                 LocalTime.of(9, 0),
-                LocalTime.of(15, 30)
+                LocalTime.of(15, 30),
+                30.0
         ),
         NASDAQ(
                 Locale.US,
                 ZoneId.of("America/New_York"),
                 2,
                 LocalTime.of(9, 30),
-                LocalTime.of(16, 0)
+                LocalTime.of(16, 0),
+                null
         );
 
         private final Locale locale;
@@ -171,6 +178,11 @@ public class Stock extends SelfValidating<Stock> {
         private final int decimalPlaces;
         private final LocalTime marketOpenTime;
         private final LocalTime marketCloseTime;
+        private final Double limitUpRatePercent;
+
+        public boolean isLimitUp(double changeRate) {
+            return limitUpRatePercent != null && changeRate >= (limitUpRatePercent * 0.99); // 29.7 for 30%
+        }
 
         /**
          * 현재 시간이 장중인지 확인 (해당 시장 기준)

--- a/src/main/java/app/xray/stock/stock_service/domain/TradeTick.java
+++ b/src/main/java/app/xray/stock/stock_service/domain/TradeTick.java
@@ -59,4 +59,16 @@ public class TradeTick extends SelfValidating<TradeTick> {
         tick.validateSelf();
         return tick;
     }
+
+    public void updateChangeRate(double close) {
+        if (close == 0.0) {
+            clearChangeRate();
+            return;
+        }
+        this.changeRate = ((this.price - close) / close) * 100.0;
+    }
+
+    public void clearChangeRate() {
+        this.changeRate = 0.0;
+    }
 }

--- a/src/main/java/app/xray/stock/stock_service/domain/TradeTicksCandleConverter.java
+++ b/src/main/java/app/xray/stock/stock_service/domain/TradeTicksCandleConverter.java
@@ -1,7 +1,7 @@
 package app.xray.stock.stock_service.domain;
 
 import app.xray.stock.stock_service.common.type.CandleIntervalType;
-import app.xray.stock.stock_service.domain.Stock.MarketType;
+import app.xray.stock.stock_service.domain.type.MarketType;
 import app.xray.stock.stock_service.domain.vo.Candle;
 import app.xray.stock.stock_service.domain.vo.TimeRange;
 import org.springframework.util.Assert;

--- a/src/main/java/app/xray/stock/stock_service/domain/type/MarketType.java
+++ b/src/main/java/app/xray/stock/stock_service/domain/type/MarketType.java
@@ -1,0 +1,93 @@
+package app.xray.stock.stock_service.domain.type;
+
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.*;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * MarketType 는 시장 구분을 정의하는 enum 입니다.
+ * <pre>
+ * - decimalPlaces: 해당 시장에서 사용하는 기본 소숫점 자리수
+ * </pre>
+ */
+@Getter
+@RequiredArgsConstructor
+public enum MarketType {
+    KOSPI(
+            Locale.KOREA,
+            ZoneId.of("Asia/Seoul"),
+            0,
+            LocalTime.of(9, 0),
+            LocalTime.of(15, 30),
+            30.0
+    ),
+    NASDAQ(
+            Locale.US,
+            ZoneId.of("America/New_York"),
+            2,
+            LocalTime.of(9, 30),
+            LocalTime.of(16, 0),
+            null
+    );
+
+    private final Locale locale;
+    private final ZoneId zoneId;
+    private final int decimalPlaces;
+    private final LocalTime marketOpenTime;
+    private final LocalTime marketCloseTime;
+    private final Double limitUpRatePercent;
+
+    public boolean isLimitUp(double changeRate) {
+        return limitUpRatePercent != null && changeRate >= (limitUpRatePercent * 0.99); // 29.7 for 30%
+    }
+
+    /**
+     * 현재 시간이 장중인지 확인 (해당 시장 기준)
+     */
+    public boolean isMarketOpenNow(Instant now) {
+        ZonedDateTime zonedNow = now.atZone(zoneId);
+        LocalTime localTime = zonedNow.toLocalTime();
+        return !isHoliday(zonedNow.toLocalDate()) && !localTime.isBefore(marketOpenTime) && localTime.isBefore(marketCloseTime);
+    }
+
+    public boolean isHoliday(LocalDate date) {
+        return isWeekend(date) || isNationalHoliday(date);
+    }
+
+    private boolean isWeekend(LocalDate date) {
+        DayOfWeek day = date.getDayOfWeek();
+        return day == DayOfWeek.SATURDAY || day == DayOfWeek.SUNDAY;
+    }
+
+    private boolean isNationalHoliday(LocalDate date) {
+        return switch (this) {
+            // TODO 리스트업 - 추석 설날 음력 변수.. ㅠ -> 행정안전부 공휴일 API 적용해야 정확
+            case KOSPI -> Set.of(
+                    LocalDate.of(2025, 1, 1),   // 신정
+                    LocalDate.of(2025, 3, 1),   // 삼일절
+                    LocalDate.of(2025, 6, 6),   // 현충일 등등
+                    LocalDate.of(2025, 12, 25),   // 크리스마스
+                    LocalDate.of(2025, 12, 31)    // 연말
+            ).contains(date);
+            case NASDAQ -> Set.of(
+                    LocalDate.of(2025, 7, 4),   // 미국 독립기념일
+                    LocalDate.of(2025, 12, 25)  // 크리스마스
+            ).contains(date);
+        };
+    }
+
+    public boolean isEarlyClose(LocalDate date) {
+        if (this == NASDAQ) {
+            return Set.of(
+                    LocalDate.of(2025, 7, 3),
+                    LocalDate.of(2025, 11, 28),
+                    LocalDate.of(2025, 12, 24)
+            ).contains(date);
+        }
+        return false;
+    }
+}

--- a/src/main/java/app/xray/stock/stock_service/domain/vo/Candle.java
+++ b/src/main/java/app/xray/stock/stock_service/domain/vo/Candle.java
@@ -2,18 +2,21 @@ package app.xray.stock.stock_service.domain.vo;
 
 import app.xray.stock.stock_service.common.validation.SelfValidating;
 import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Candle extends SelfValidating<Candle> {
 
     @NotNull
-    private final TimeRange timeRange;
-    private final Double open;
-    private final Double high;
-    private final Double low;
-    private final Double close;
-    private final Long volume;
+    private TimeRange timeRange;
+    private Double open;
+    private Double high;
+    private Double low;
+    private Double close;
+    private Long volume;
 
     private Candle(TimeRange timeRange, Double open, Double high, Double low, Double close, Long volume) {
         this.timeRange = timeRange;

--- a/src/main/java/app/xray/stock/stock_service/domain/vo/TimeRange.java
+++ b/src/main/java/app/xray/stock/stock_service/domain/vo/TimeRange.java
@@ -2,10 +2,7 @@ package app.xray.stock.stock_service.domain.vo;
 
 import app.xray.stock.stock_service.common.type.CandleIntervalType;
 
-import java.time.Duration;
-import java.time.Instant;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
+import java.time.*;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
@@ -17,6 +14,13 @@ public record TimeRange(Instant start, Instant end) {
 
     public static TimeRange of(Instant start, Instant end) {
         return new TimeRange(start, end);
+    }
+
+    public static TimeRange ofYesterday(Instant baseTime, ZoneId zoneId) {
+        LocalDate date = baseTime.atZone(zoneId).toLocalDate().minusDays(1);
+        Instant start = date.atStartOfDay(zoneId).toInstant();
+        Instant end = date.plusDays(1).atStartOfDay(zoneId).minusNanos(1).toInstant();
+        return of(start, end);
     }
 
     /**

--- a/src/test/java/app/xray/stock/stock_service/domain/TradeTicksCandleConverterTest.java
+++ b/src/test/java/app/xray/stock/stock_service/domain/TradeTicksCandleConverterTest.java
@@ -1,7 +1,7 @@
 package app.xray.stock.stock_service.domain;
 
 import app.xray.stock.stock_service.common.type.CandleIntervalType;
-import app.xray.stock.stock_service.domain.Stock.MarketType;
+import app.xray.stock.stock_service.domain.type.MarketType;
 import app.xray.stock.stock_service.domain.vo.Candle;
 import app.xray.stock.stock_service.domain.vo.TimeRange;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
### 주요 변경사항

1. 주식 목록 조회 엔드포인트 추가 및 관련 기능 구현
   - `/api/v1/stocks` GET 엔드포인트 신설
   - marketCode 파라미터로 특정 마켓의 주식 Top ROI 랭킹 반환
   - 응답 DTO(`StockListResponse`) 및 내부 StockItem 구조 추가

2. 주식 목록 조회 도메인 및 서비스 계층 추가
   - `QueryStockListUseCase` 인터페이스 및 구현(`StockQueryService`)
   - `StockListQuery`(marketCode 기반 쿼리) Value Object 생성
   - 주식 데이터 포트에 marketIdPrefix 기반 조회 메서드 추가

3. 이벤트 기반 주식 정보 업데이트 로직 도입
   - TradeTick 데이터 저장 시 `TradeTickSavedEvent` 이벤트 발행
   - 해당 이벤트 처리 핸들러(`TradeTickSavedEventHandler`) 추가
   - 핸들러에서 주식의 거래 정보 갱신 로직 추가

4. 관련 서비스 및 포트/어댑터 수정
   - `StockCommandService`에 거래 정보 업데이트 메서드 추가
   - 기존 서비스/포트에 이벤트 및 랭킹 조회 관련 로직 반영

5. 기타
   - DTO, 도메인, 서비스 등에서 필요한 import, DI, 어노테이션, 유틸리티 등 추가
   - 일부 TODO 명시(예: isLimitUp 구현 등)