### PR TITLE
[Socket] 실시간 주식 트레이드 틱 정보 브로트케스팅 구현 1 - 기본 netty socket io 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,8 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	implementation 'com.corundumstudio.socketio:netty-socketio:1.7.19'
 }
 
 tasks.named('test') {

--- a/src/main/java/app/xray/stock/stock_service/adapter/in/job/CollectStockTradeTickScheduler.java
+++ b/src/main/java/app/xray/stock/stock_service/adapter/in/job/CollectStockTradeTickScheduler.java
@@ -10,6 +10,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 @Log4j2
@@ -23,7 +24,7 @@ public class CollectStockTradeTickScheduler {
     @Scheduled(fixedRate = 5000)
     public void collect() {
         log.info("[CollectStockTradeTickScheduler.collect] START");
-        Instant now = Instant.now();
+        Instant now = Instant.now().truncatedTo(ChronoUnit.SECONDS);
         List<Stock> stocks = loadCollectEnableStocksUseCase.loadAll(now);
         collectTradeTickDataUseCase.collectAndSave(CollectStockCommand.of(stocks, now));
         log.info("[CollectStockTradeTickScheduler.collect] END");

--- a/src/main/java/app/xray/stock/stock_service/adapter/in/socket/TradeTickSocketEventHandler.java
+++ b/src/main/java/app/xray/stock/stock_service/adapter/in/socket/TradeTickSocketEventHandler.java
@@ -1,0 +1,26 @@
+package app.xray.stock.stock_service.adapter.in.socket;
+
+import app.xray.stock.stock_service.common.event.TradeTickSavedEvent;
+import app.xray.stock.stock_service.domain.TradeTick;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TradeTickSocketEventHandler {
+
+    private final TradeTickSocketGateway socketGateway;
+
+    @Async
+    @EventListener
+    public void onTradeTickSaved(TradeTickSavedEvent event) {
+        for (TradeTick tick : event.data()) {
+            log.debug("[TradeTickSocketEventHandler] broadcasting tick: {} to {}", tick.getPrice(), tick.getStockId());
+            socketGateway.sendTickToRoom(tick.getStockId(), tick);
+        }
+    }
+}

--- a/src/main/java/app/xray/stock/stock_service/adapter/in/socket/TradeTickSocketEventHandler.java
+++ b/src/main/java/app/xray/stock/stock_service/adapter/in/socket/TradeTickSocketEventHandler.java
@@ -18,9 +18,7 @@ public class TradeTickSocketEventHandler {
     @Async
     @EventListener
     public void onTradeTickSaved(TradeTickSavedEvent event) {
-        for (TradeTick tick : event.data()) {
-            log.debug("[TradeTickSocketEventHandler] broadcasting tick: {} to {}", tick.getPrice(), tick.getStockId());
-            socketGateway.sendTickToRoom(tick.getStockId(), tick);
-        }
+        log.debug("[TradeTickSocketEventHandler] broadcasting event: {}", event);
+        socketGateway.sendTickToRoom(event.stockId(), event.start(), event.end(), event.data());
     }
 }

--- a/src/main/java/app/xray/stock/stock_service/adapter/in/socket/TradeTickSocketGateway.java
+++ b/src/main/java/app/xray/stock/stock_service/adapter/in/socket/TradeTickSocketGateway.java
@@ -1,0 +1,40 @@
+package app.xray.stock.stock_service.adapter.in.socket;
+
+import app.xray.stock.stock_service.domain.TradeTick;
+import com.corundumstudio.socketio.SocketIOServer;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Component;
+
+@Log4j2
+@Component
+@RequiredArgsConstructor
+public class TradeTickSocketGateway {
+
+    private final SocketIOServer server;
+
+    @PostConstruct
+    public void init() {
+        server.addConnectListener(client -> {
+            log.info("[TradeTickSocketGateway.server.ConnectListener] client connected: sessionId = {}",
+                    client.getSessionId());
+        });
+
+        server.addDisconnectListener(client -> {
+            log.info("[TradeTickSocketGateway.server.DisconnectListener] client disconnected: sessionId = {}",
+                    client.getSessionId());
+        });
+
+        server.addEventListener("joinRoom", String.class, (client, roomName, ackSender) -> {
+            client.joinRoom(roomName);
+            log.info("[TradeTickSocketGateway.server.EventListener] client joined room: sessionId = {}, roomName = {}",
+                    client.getSessionId(), roomName);
+        });
+    }
+
+    // 특정 symbol 방에 TradeTick 정보 broadcast
+    public void sendTickToRoom(String symbol, TradeTick tradeTick) {
+        server.getRoomOperations(symbol).sendEvent("tickUpdate", tradeTick);
+    }
+}

--- a/src/main/java/app/xray/stock/stock_service/adapter/in/socket/TradeTickSocketGateway.java
+++ b/src/main/java/app/xray/stock/stock_service/adapter/in/socket/TradeTickSocketGateway.java
@@ -4,11 +4,12 @@ import app.xray.stock.stock_service.adapter.in.socket.dto.TradeTickMessage;
 import app.xray.stock.stock_service.domain.TradeTick;
 import com.corundumstudio.socketio.SocketIOServer;
 import jakarta.annotation.PostConstruct;
-import jakarta.validation.constraints.Positive;
-import jakarta.validation.constraints.PositiveOrZero;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.List;
 
 @Log4j2
 @Component
@@ -37,15 +38,14 @@ public class TradeTickSocketGateway {
     }
 
     // 특정 stockId 방에 TradeTick 정보 broadcast
-    public void sendTickToRoom(String symbol, TradeTick tick) {
-        var room = server.getRoomOperations(symbol);
-
+    public void sendTickToRoom(String stockId, Instant start, Instant end, List<TradeTick> tradeTicks) {
+        var room = server.getRoomOperations(stockId);
         // 방에 클라이언트가 1명 이상 있는 경우에만 전송
         if (!room.getClients().isEmpty()) {
-            log.debug("✅ Broadcasting tick to {} clients in room {}", room.getClients().size(), symbol);
-            room.sendEvent("tickUpdate", TradeTickMessage.from(tick));
+            log.debug("✅ Broadcasting tradeTicks to {} clients in room {}", room.getClients().size(), stockId);
+            room.sendEvent("tickUpdate", TradeTickMessage.of(stockId, start, end, tradeTicks));
         } else {
-            log.debug("⏸️ No clients in room {} — skip broadcasting", symbol);
+            log.debug("⏸️ No clients in room {} — skip broadcasting", stockId);
         }
     }
 }

--- a/src/main/java/app/xray/stock/stock_service/adapter/in/socket/dto/TradeTickMessage.java
+++ b/src/main/java/app/xray/stock/stock_service/adapter/in/socket/dto/TradeTickMessage.java
@@ -4,18 +4,28 @@ import app.xray.stock.stock_service.domain.TradeTick;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.PositiveOrZero;
 
+import java.time.Instant;
+import java.util.List;
+
 public record TradeTickMessage(String stockId,
-                               @Positive double price,
-                               double changeRate,
-                               @PositiveOrZero long volume,
-                               String tickAt) {
-    public static TradeTickMessage from(TradeTick tick) {
+                               String start,
+                               String end,
+                               List<TradeTickItem> tradeTickItems) {
+    public static TradeTickMessage of(String stockId, Instant start, Instant end, List<TradeTick> ticks) {
+
         return new TradeTickMessage(
-                tick.getStockId(),
-                tick.getPrice(),
-                tick.getChangeRate(),
-                tick.getVolume(),
-                tick.getTickAt().toString()
-        );
+                stockId, start.toString(), end.toString(),
+                ticks.stream().map(TradeTickItem::from).toList());
+    }
+
+
+    record TradeTickItem(@Positive double price,
+                         double changeRate,
+                         @PositiveOrZero long volume,
+                         String tickAt) {
+        public static TradeTickItem from(TradeTick tradeTick) {
+            return new TradeTickItem(tradeTick.getPrice(), tradeTick.getChangeRate(), tradeTick.getVolume(),
+                    tradeTick.getTickAt().toString());
+        }
     }
 }

--- a/src/main/java/app/xray/stock/stock_service/adapter/in/socket/dto/TradeTickMessage.java
+++ b/src/main/java/app/xray/stock/stock_service/adapter/in/socket/dto/TradeTickMessage.java
@@ -1,0 +1,21 @@
+package app.xray.stock.stock_service.adapter.in.socket.dto;
+
+import app.xray.stock.stock_service.domain.TradeTick;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+
+public record TradeTickMessage(String stockId,
+                               @Positive double price,
+                               double changeRate,
+                               @PositiveOrZero long volume,
+                               String tickAt) {
+    public static TradeTickMessage from(TradeTick tick) {
+        return new TradeTickMessage(
+                tick.getStockId(),
+                tick.getPrice(),
+                tick.getChangeRate(),
+                tick.getVolume(),
+                tick.getTickAt().toString()
+        );
+    }
+}

--- a/src/main/java/app/xray/stock/stock_service/application/service/StockCommandService.java
+++ b/src/main/java/app/xray/stock/stock_service/application/service/StockCommandService.java
@@ -59,11 +59,11 @@ public class StockCommandService implements SaveStockUseCase, StartCollectingSto
                 .orElseThrow();
 
         if (stock.needsToUpdatePreviousCandle()) {
-            TimeRange range = TimeRange.ofYesterday(current.getTickAt(), stock.getMarketType().getZoneId());
-            List<TradeTick> yesterdayTicks = loadTradeTickDataPort
-                    .loadTradeTicksDataByRange(stockId, range.start(), range.end());
+            TimeRange previousBusinessDayTimeRange = stock.getPreviousBusinessDayTimeRange();
+            List<TradeTick> previousTicks = loadTradeTickDataPort
+                    .loadTradeTicksDataByRange(stockId, previousBusinessDayTimeRange.start(), previousBusinessDayTimeRange.end());
 
-            stock.updatePreviousCandleWith(yesterdayTicks);
+            stock.updatePreviousCandleWith(previousBusinessDayTimeRange, previousTicks);
         }
         stock.updateCurrentTradeTick(current);
         saveStockDataPort.save(stock);

--- a/src/main/java/app/xray/stock/stock_service/application/service/TradeTickCommandService.java
+++ b/src/main/java/app/xray/stock/stock_service/application/service/TradeTickCommandService.java
@@ -47,12 +47,12 @@ public class TradeTickCommandService implements CollectTradeTickDataUseCase {
                     rangeTradeTicksResponse.size(),
                     start, end);
 
-            // 저장 처리 진행
-            saveTradeTickDataPort.saveAll(TradeTick.fromResponses(
-                    stock.getId(), rangeTradeTicksResponse));
+            // 변화 후 저장 처리 진행
+            List<TradeTick> tradeTicks = TradeTick.fromResponses(stock.getId(), rangeTradeTicksResponse);
+            saveTradeTickDataPort.saveAll(tradeTicks);
 
             // 이벤트 발행
-            eventPublisher.publishEvent(new TradeTickSavedEvent(stock.getId(), start, end));
+            eventPublisher.publishEvent(new TradeTickSavedEvent(stock.getId(), start, end, tradeTicks));
         }
     }
 }

--- a/src/main/java/app/xray/stock/stock_service/common/config/SocketIOConfig.java
+++ b/src/main/java/app/xray/stock/stock_service/common/config/SocketIOConfig.java
@@ -1,0 +1,38 @@
+package app.xray.stock.stock_service.common.config;
+
+import com.corundumstudio.socketio.SocketIOServer;
+import com.corundumstudio.socketio.Transport;
+import com.corundumstudio.socketio.protocol.JacksonJsonSupport;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SocketIOConfig {
+
+    @Value("${socket.host:localhost}")
+    private String host;
+
+    @Value("${socket.port:9092}")
+    private Integer port;
+
+    @Bean
+    public SocketIOServer socketIOServer() {
+        com.corundumstudio.socketio.Configuration config = new com.corundumstudio.socketio.Configuration();
+        config.setHostname(host);
+        config.setPort(port);
+        config.setTransports(Transport.WEBSOCKET); // 강제 웹소켓 only
+        return new SocketIOServer(config);
+    }
+
+    @Bean
+    public ApplicationRunner runner(SocketIOServer server) {
+        return args -> {
+            server.start();
+        };
+    }
+}

--- a/src/main/java/app/xray/stock/stock_service/common/event/TradeTickSavedEvent.java
+++ b/src/main/java/app/xray/stock/stock_service/common/event/TradeTickSavedEvent.java
@@ -1,6 +1,9 @@
 package app.xray.stock.stock_service.common.event;
 
 
-import java.time.Instant;
+import app.xray.stock.stock_service.domain.TradeTick;
 
-public record TradeTickSavedEvent(String stockId, Instant start, Instant end) { }
+import java.time.Instant;
+import java.util.List;
+
+public record TradeTickSavedEvent(String stockId, Instant start, Instant end, List<TradeTick> data) { }

--- a/src/main/java/app/xray/stock/stock_service/domain/vo/TimeRange.java
+++ b/src/main/java/app/xray/stock/stock_service/domain/vo/TimeRange.java
@@ -16,6 +16,12 @@ public record TimeRange(Instant start, Instant end) {
         return new TimeRange(start, end);
     }
 
+    public static TimeRange forDay(LocalDate date, ZoneId zoneId) {
+        Instant start = date.atStartOfDay(zoneId).toInstant();
+        Instant end = date.plusDays(1).atStartOfDay(zoneId).minusNanos(1).toInstant();
+        return new TimeRange(start, end);
+    }
+
     public static TimeRange ofYesterday(Instant baseTime, ZoneId zoneId) {
         LocalDate date = baseTime.atZone(zoneId).toLocalDate().minusDays(1);
         Instant start = date.atStartOfDay(zoneId).toInstant();


### PR DESCRIPTION
### [Socket] 실시간 주식 트레이드 틱 정보 브로드캐스팅 구현 - 기본 netty socket io 적용
- socket.io의 방개념을 활용하여 같은 주식 식별값에 포함된 소켓 연결 사용자에게 주식 틱정보 이벤트 수신시 브로드케스트 하는 형태로 구현, 단, 스케일 아웃 환경에서 안됨
- netty-socketio 기본 설정에 용이한 코드

---

### 주요 변경사항

- Netty 기반의 socketio 서버 도입 및 초기 설정 (`netty-socketio` 라이브러리 의존성 추가)
- 소켓 서버를 통한 실시간 트레이드 틱 정보 브로드캐스팅 인프라 구축
- 도메인 이벤트(`TradeTickSavedEvent`)와 소켓 브로드캐스트 연동
- 종목별(Room 기반) 실시간 데이터 구독/해제 및 전달 구조 설계
- 실시간 데이터 전달용 DTO 정의 및 전송 포맷 표준화
- 관련 서비스 코드 개선 및 리팩터링

---

### 상세 내용

#### Netty(socketio) 서버 초기 설정 및 구조

- `SocketIOConfig`에서 소켓 서버의 호스트, 포트, 트랜스포트(Websocket Only) 설정을 담당하고, Spring Bean으로 등록하여 애플리케이션 시작 시 자동으로 서버가 실행됩니다.
- 서버는 클라이언트의 connect/disconnect, room join 등 다양한 이벤트를 리스닝하며, 각 이벤트에 대한 로그 및 처리를 담당합니다.
- socketio를 통해 종목별(room)로 클라이언트가 구독/해제할 수 있는 구조를 구성했습니다.

#### 소켓 브로드캐스트 및 이벤트 흐름

- 트레이드 틱 데이터가 저장되면, `TradeTickCommandService`가 `TradeTickSavedEvent`를 발행합니다.
- `TradeTickSocketEventHandler`가 해당 이벤트를 비동기로 수신하며, 내부적으로 `TradeTickSocketGateway`의 `sendTickToRoom`을 호출해 실시간 데이터(틱 정보)를 소켓을 통해 해당 종목(Room)에 구독 중인 클라이언트에게 브로드캐스팅합니다.
- 데이터는 `TradeTickMessage` DTO로 직렬화되어 전송됩니다.

#### 핵사고날(Hexagonal) 아키텍처 상 위치 및 역할

- socketio 관련 클래스(`SocketIOConfig`, `TradeTickSocketGateway`, `TradeTickSocketEventHandler`, `TradeTickMessage`)는 **adapter/in**(driving adapter)로, 외부의 실시간 연결 및 데이터 전송을 담당합니다.
- 이벤트 객체(`TradeTickSavedEvent`)는 **common.event**에서 도메인과 어댑터 사이의 메시지 역할을 합니다.
- 비즈니스 로직(틱 데이터 저장, 이벤트 발행 등)은 **application/service** 계층에서 관리합니다.

#### 주요 클래스 및 상호작용

- `SocketIOConfig`: 소켓 서버 설정 및 실행(Spring Bean)
- `TradeTickSocketGateway`: 소켓 서버의 핵심, 이벤트 리스너 등록, 실시간 데이터 브로드캐스트
- `TradeTickSocketEventHandler`: 도메인 이벤트 수신, gateway를 통해 실시간 데이터 전송 트리거
- `TradeTickMessage`: 데이터 전달 포맷 DTO 정의
- `TradeTickSavedEvent`: 트레이드 틱 데이터가 저장될 때 발행되는 도메인 이벤트
- `TradeTickCommandService`: 틱 데이터 저장 및 이벤트 발행

##### 상호작용 흐름 요약

1. 트레이드 틱 데이터 저장 → `TradeTickCommandService`에서 처리, 저장 후 `TradeTickSavedEvent` 발행
2. `TradeTickSocketEventHandler`가 이벤트 비동기 수신
3. Handler가 Gateway의 `sendTickToRoom` 호출 → 해당 종목 room에 실시간 데이터 브로드캐스팅
4. 클라이언트는 joinRoom으로 방 입장 후 실시간 데이터 구독

---

### 변경/추가 파일 요약 (일부)

- `build.gradle` : netty-socketio 의존성 추가
- `src/main/java/app/xray/stock/stock_service/common/config/SocketIOConfig.java` : socketio 서버 설정
- `src/main/java/app/xray/stock/stock_service/adapter/in/socket/TradeTickSocketGateway.java` : 소켓 서버 게이트웨이/브로드캐스트
- `src/main/java/app/xray/stock/stock_service/adapter/in/socket/TradeTickSocketEventHandler.java` : 이벤트 핸들러
- `src/main/java/app/xray/stock/stock_service/adapter/in/socket/dto/TradeTickMessage.java` : 데이터 전달 DTO
- `src/main/java/app/xray/stock/stock_service/common/event/TradeTickSavedEvent.java` : 이벤트 객체
- `src/main/java/app/xray/stock/stock_service/application/service/TradeTickCommandService.java` : 서비스 계층

전체 파일 및 상세 변경 내역은 [PR 파일 변경 목록](https://github.com/xray-stock/xray-stock-service-sq/pull/16/files) 참고

---

### 테스트 및 검증

- 여러 클라이언트에서 종목 room join/leave 반복, 데이터 실시간 수신 정상 동작 확인
- 예외 및 네트워크 장애 상황에서의 연결 복구 및 안정성 검증
- 유닛/통합 테스트 코드 및 로그 검증

---

### 기타/후속 계획

- 추후 주문 체결, 시세 등 다양한 실시간 브로드캐스팅 이벤트 확장 예정
- 코드 리팩터링, 성능 최적화는 별도 PR로 진행 예정

---