### PR TITLE
[Socket] 실시간 주식 트레이드 틱 정보 브로트케스팅 구현 2 - 스케일 아웃 환경 고려하여 Redis PUB/SUB 으로 같은 방(주식) 브로드캐스팅 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/app/xray/stock/stock_service/adapter/in/redis/RedisPublishTradeTickEventHandler.java
+++ b/src/main/java/app/xray/stock/stock_service/adapter/in/redis/RedisPublishTradeTickEventHandler.java
@@ -1,7 +1,8 @@
-package app.xray.stock.stock_service.adapter.in.socket;
+package app.xray.stock.stock_service.adapter.in.redis;
 
+import app.xray.stock.stock_service.adapter.in.socket.dto.TradeTickMessage;
+import app.xray.stock.stock_service.adapter.out.redis.RedisTradeTickPublisher;
 import app.xray.stock.stock_service.common.event.TradeTickSavedEvent;
-import app.xray.stock.stock_service.domain.TradeTick;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
@@ -11,14 +12,14 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class TradeTickSocketEventHandler {
+public class RedisPublishTradeTickEventHandler {
 
-    private final TradeTickSocketGateway socketGateway;
+    private final RedisTradeTickPublisher redisPublisher;
 
     @Async
     @EventListener
     public void onTradeTickSaved(TradeTickSavedEvent event) {
         log.debug("[TradeTickSocketEventHandler] broadcasting event: {}", event);
-        socketGateway.sendTickToRoom(event.stockId(), event.start(), event.end(), event.data());
+        redisPublisher.publish(TradeTickMessage.of(event.stockId(), event.start(), event.end(), event.data()));
     }
 }

--- a/src/main/java/app/xray/stock/stock_service/adapter/in/redis/RedisTradeTickSubscriber.java
+++ b/src/main/java/app/xray/stock/stock_service/adapter/in/redis/RedisTradeTickSubscriber.java
@@ -1,0 +1,34 @@
+package app.xray.stock.stock_service.adapter.in.redis;
+
+import app.xray.stock.stock_service.adapter.in.socket.TradeTickSocketGateway;
+import app.xray.stock.stock_service.adapter.in.socket.dto.TradeTickMessage;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisTradeTickSubscriber implements MessageListener {
+
+    private final ObjectMapper objectMapper;
+    private final TradeTickSocketGateway socketGateway;
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        try {
+            String body = message.toString();
+            TradeTickMessage tradeTickMessage = objectMapper.readValue(body, TradeTickMessage.class);
+            log.debug("Redis listening: {}", tradeTickMessage);
+
+            // WebSocket room 에 전송
+            socketGateway.sendTickToRoom(tradeTickMessage);
+
+        } catch (Exception e) {
+            log.error("FAIL! Redis making message process", e);
+        }
+    }
+}

--- a/src/main/java/app/xray/stock/stock_service/adapter/in/socket/TradeTickSocketGateway.java
+++ b/src/main/java/app/xray/stock/stock_service/adapter/in/socket/TradeTickSocketGateway.java
@@ -40,12 +40,31 @@ public class TradeTickSocketGateway {
     // 특정 stockId 방에 TradeTick 정보 broadcast
     public void sendTickToRoom(String stockId, Instant start, Instant end, List<TradeTick> tradeTicks) {
         var room = server.getRoomOperations(stockId);
-        // 방에 클라이언트가 1명 이상 있는 경우에만 전송
-        if (!room.getClients().isEmpty()) {
-            log.debug("✅ Broadcasting tradeTicks to {} clients in room {}", room.getClients().size(), stockId);
-            room.sendEvent("tickUpdate", TradeTickMessage.of(stockId, start, end, tradeTicks));
-        } else {
+
+        if (room.getClients().isEmpty()) {
             log.debug("⏸️ No clients in room {} — skip broadcasting", stockId);
+            return;
         }
+
+        // 방에 클라이언트가 1명 이상 있는 경우에만 전송
+        log.debug("✅ Broadcasting tradeTicks to {} clients in room {}", room.getClients().size(), stockId);
+        room.sendEvent("tickUpdate", TradeTickMessage.of(stockId, start, end, tradeTicks));
     }
+
+    // 특정 stockId 방에 TradeTick 정보 broadcast
+    public void sendTickToRoom(TradeTickMessage tradeTickMessage) {
+        String stockId = tradeTickMessage.stockId();
+        var room = server.getRoomOperations(stockId);
+
+        if (room.getClients().isEmpty()) {
+            log.debug("⏸️ No clients in room {} — skip broadcasting", tradeTickMessage.stockId());
+            return;
+        }
+
+        // 방에 클라이언트가 1명 이상 있는 경우에만 전송
+        log.debug("✅ Broadcasting tradeTicks to {} clients in room {}", room.getClients().size(), stockId);
+        room.sendEvent("tickUpdate", tradeTickMessage);
+    }
+
+
 }

--- a/src/main/java/app/xray/stock/stock_service/adapter/out/redis/RedisTradeTickPublisher.java
+++ b/src/main/java/app/xray/stock/stock_service/adapter/out/redis/RedisTradeTickPublisher.java
@@ -1,0 +1,30 @@
+package app.xray.stock.stock_service.adapter.out.redis;
+
+import app.xray.stock.stock_service.adapter.in.socket.dto.TradeTickMessage;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisTradeTickPublisher {
+
+    private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    private static final String CHANNEL = "xray::stock-service::trade-tick";
+
+    public void publish(TradeTickMessage message) {
+        try {
+            String json = objectMapper.writeValueAsString(message);
+            redisTemplate.convertAndSend(CHANNEL, json);
+            log.debug("Redis publish to channel '{}': {}", CHANNEL, json);
+        } catch (JsonProcessingException e) {
+            log.error("Redis publish FAIL - JSON Serialization", e);
+        }
+    }
+}

--- a/src/main/java/app/xray/stock/stock_service/adapter/out/redis/RedisTradeTickPublisher.java
+++ b/src/main/java/app/xray/stock/stock_service/adapter/out/redis/RedisTradeTickPublisher.java
@@ -1,6 +1,7 @@
 package app.xray.stock.stock_service.adapter.out.redis;
 
 import app.xray.stock.stock_service.adapter.in.socket.dto.TradeTickMessage;
+import app.xray.stock.stock_service.common.constant.RedisChannel;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
@@ -16,13 +17,11 @@ public class RedisTradeTickPublisher {
     private final StringRedisTemplate redisTemplate;
     private final ObjectMapper objectMapper;
 
-    private static final String CHANNEL = "xray::stock-service::trade-tick";
-
     public void publish(TradeTickMessage message) {
         try {
             String json = objectMapper.writeValueAsString(message);
-            redisTemplate.convertAndSend(CHANNEL, json);
-            log.debug("Redis publish to channel '{}': {}", CHANNEL, json);
+            redisTemplate.convertAndSend(RedisChannel.TRADE_TICK, json);
+            log.debug("Redis publish to channel '{}': {}", RedisChannel.TRADE_TICK, json);
         } catch (JsonProcessingException e) {
             log.error("Redis publish FAIL - JSON Serialization", e);
         }

--- a/src/main/java/app/xray/stock/stock_service/application/handler/TradeTickSavedEventHandler.java
+++ b/src/main/java/app/xray/stock/stock_service/application/handler/TradeTickSavedEventHandler.java
@@ -1,8 +1,7 @@
 package app.xray.stock.stock_service.application.handler;
 
 
-import app.xray.stock.stock_service.adapter.in.socket.dto.TradeTickMessage;
-import app.xray.stock.stock_service.adapter.out.redis.RedisTradeTickPublisher;
+import app.xray.stock.stock_service.application.service.StockCommandService;
 import app.xray.stock.stock_service.common.event.TradeTickSavedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -15,13 +14,17 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class TradeTickSavedEventHandler {
 
-    private final RedisTradeTickPublisher redisPublisher;
+    private final StockCommandService service;
 
     @Async
     @EventListener
     public void handleTradeTickSavedEvent(TradeTickSavedEvent event) {
-        log.debug("[TradeTickSavedEventHandler] publish to redis: {}", event.stockId());
-        redisPublisher.publish(TradeTickMessage.of(event.stockId(), event.start(), event.end(), event.data()));
+        log.info("[TradeTickSavedEventHandler.handleTradeTickSavedEvent] " +
+                        "stockId={}, " +
+                        "timeRange.start={}, " +
+                        "timeRange.end={}",
+                event.stockId(), event.start(), event.end());
+        service.updateTradingInfo(event.stockId());
     }
 
 }

--- a/src/main/java/app/xray/stock/stock_service/application/handler/TradeTickSavedEventHandler.java
+++ b/src/main/java/app/xray/stock/stock_service/application/handler/TradeTickSavedEventHandler.java
@@ -1,7 +1,8 @@
 package app.xray.stock.stock_service.application.handler;
 
 
-import app.xray.stock.stock_service.application.service.StockCommandService;
+import app.xray.stock.stock_service.adapter.in.socket.dto.TradeTickMessage;
+import app.xray.stock.stock_service.adapter.out.redis.RedisTradeTickPublisher;
 import app.xray.stock.stock_service.common.event.TradeTickSavedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -14,17 +15,13 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class TradeTickSavedEventHandler {
 
-    private final StockCommandService service;
+    private final RedisTradeTickPublisher redisPublisher;
 
     @Async
     @EventListener
     public void handleTradeTickSavedEvent(TradeTickSavedEvent event) {
-        log.info("[TradeTickSavedEventHandler.handleTradeTickSavedEvent] " +
-                        "stockId={}, " +
-                        "timeRange.start={}, " +
-                        "timeRange.end={}",
-                event.stockId(), event.start(), event.end());
-        service.updateTradingInfo(event.stockId());
+        log.debug("[TradeTickSavedEventHandler] publish to redis: {}", event.stockId());
+        redisPublisher.publish(TradeTickMessage.of(event.stockId(), event.start(), event.end(), event.data()));
     }
 
 }

--- a/src/main/java/app/xray/stock/stock_service/common/config/RedisSubscriberConfig.java
+++ b/src/main/java/app/xray/stock/stock_service/common/config/RedisSubscriberConfig.java
@@ -1,0 +1,29 @@
+package app.xray.stock.stock_service.common.config;
+
+import app.xray.stock.stock_service.adapter.in.redis.RedisTradeTickSubscriber;
+import app.xray.stock.stock_service.adapter.out.redis.RedisTradeTickPublisher;
+import app.xray.stock.stock_service.common.constant.RedisChannel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.listener.PatternTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+
+import jakarta.annotation.PostConstruct;
+
+@Configuration
+@RequiredArgsConstructor
+public class RedisSubscriberConfig {
+
+    private final RedisConnectionFactory connectionFactory;
+    private final RedisTradeTickSubscriber subscriber;
+
+    @PostConstruct
+    public void subscribe() {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+        container.addMessageListener(subscriber, new PatternTopic(RedisChannel.TRADE_TICK));
+        container.afterPropertiesSet();
+        container.start();
+    }
+}

--- a/src/main/java/app/xray/stock/stock_service/common/constant/RedisChannel.java
+++ b/src/main/java/app/xray/stock/stock_service/common/constant/RedisChannel.java
@@ -1,0 +1,7 @@
+package app.xray.stock.stock_service.common.constant;
+
+public final class RedisChannel {
+    public static final String TRADE_TICK = "xray::stock-service::trade-tick";
+
+    private RedisChannel() {}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,6 +9,10 @@ spring:
       database: xray-stock
       username: ${MONGO_USER}
       password: ${MONGO_PASS}
+    redis:
+      host: ${REDIS_URL:localhost}
+      port: ${REDIS_PORT:6379}
+      password: ${REDIS_PASS}
 
 management:
   endpoints:


### PR DESCRIPTION
### [Socket] 실시간 주식 트레이드 틱 정보 브로드캐스팅 구현 2  
#### - 스케일 아웃 환경 고려하여 Redis PUB/SUB 으로 같은 방 브로드캐스팅 구현

---

### 주요 변경사항

- Redis Pub/Sub 도입으로 여러 인스턴스 간 실시간 주식 트레이드 틱 정보 브로드캐스팅 지원
- 기존 socket 브로드캐스트 이벤트 핸들러를 Redis 퍼블리셔/서브스크라이버 구조로 리팩터링
- Redis 채널 상수 및 환경설정 추가

---

### 상세 내용

#### Redis Pub/Sub 구조 도입

- 트레이드 틱 이벤트 발생 시, `RedisTradeTickPublisher`가 Redis 채널로 실시간 데이터를 publish
- `RedisTradeTickSubscriber`가 채널을 구독하여, 수신된 메시지를 socket room에 브로드캐스트
- 여러 인스턴스 간에도 동일한 방(room) 클라이언트에게 일관된 실시간 데이터 전송을 보장

#### 주요 클래스 및 상호작용

- `RedisPublishTradeTickEventHandler`: 도메인 이벤트 수신 후 Redis Pub으로 브로드캐스트 트리거
- `RedisTradeTickPublisher`: Redis 채널(`xray::stock-service::trade-tick`)로 메시지 publish
- `RedisSubscriberConfig`: Redis Pub/Sub 리스너 컨테이너 설정, 구독자 바인딩
- `RedisTradeTickSubscriber`: Redis 메시지 수신, socket room으로 실시간 데이터 전송
- `TradeTickSocketGateway`: 기존 socket 브로드캐스트 로직 일부 수정 (TradeTickMessage 직접 수신 가능)
- `RedisChannel`: Redis 채널 상수 정의
- 환경설정(`application.yml`): Redis 접속 정보 추가

#### 상호작용 흐름 요약

1. 트레이드 틱 데이터 저장 → `TradeTickSavedEvent` 발행
2. `RedisPublishTradeTickEventHandler` → Redis 채널로 메시지 publish
3. 모든 인스턴스의 `RedisTradeTickSubscriber`가 메시지 수신
4. 각 인스턴스의 `TradeTickSocketGateway`가 해당 방(room) 클라이언트에 실시간 데이터 브로드캐스트

---

### 변경/추가 파일 요약

- `build.gradle` : Redis 관련 의존성 추가
- `src/main/resources/application.yml` : Redis 설정 추가
- `src/main/java/app/xray/stock/stock_service/adapter/in/redis/RedisPublishTradeTickEventHandler.java` : 이벤트 핸들러(퍼블리셔) 추가/이동
- `src/main/java/app/xray/stock/stock_service/adapter/out/redis/RedisTradeTickPublisher.java` : 퍼블리셔 구현
- `src/main/java/app/xray/stock/stock_service/adapter/in/redis/RedisTradeTickSubscriber.java` : 서브스크라이버 구현(신규)
- `src/main/java/app/xray/stock/stock_service/common/config/RedisSubscriberConfig.java` : Redis 리스너 설정(신규)
- `src/main/java/app/xray/stock/stock_service/common/constant/RedisChannel.java` : 채널 상수(신규)
- `src/main/java/app/xray/stock/stock_service/adapter/in/socket/TradeTickSocketGateway.java` : 메시지 브로드캐스트 메서드 오버로드 및 수정

---

### 테스트 및 검증

- 여러 인스턴스/클라이언트 환경에서 동일 room join 시 실시간 데이터 동기화 정상 동작 확인
- Redis 장애/네트워크 상황에서의 예외 처리 및 복구 확인
- 단위/통합 테스트 및 로그 검증

---

### 기타/후속 계획

- [x] 인증 처리 구현
- [ ] 브로드캐스팅 이벤트(주문 체결, 시세 등) 추가 확장 예정
- [ ] 코드 리팩터링, 성능 최적화, 장애 상황 모니터링 등은 별도 PR로 진행
