### PR TITLE
[Socket] 실시간 주식 트레이드 틱 정보 브로트케스팅 구현 3 - JWT 인증처리 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,11 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	implementation 'com.corundumstudio.socketio:netty-socketio:1.7.19'
+
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/app/xray/stock/stock_service/adapter/in/socket/SocketAuthorizationListener.java
+++ b/src/main/java/app/xray/stock/stock_service/adapter/in/socket/SocketAuthorizationListener.java
@@ -1,0 +1,27 @@
+package app.xray.stock.stock_service.adapter.in.socket;
+
+import com.corundumstudio.socketio.AuthorizationListener;
+import com.corundumstudio.socketio.HandshakeData;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SocketAuthorizationListener implements AuthorizationListener {
+
+    @Value("${socketio.secret-key}")
+    private String secretKey;
+
+    @Override
+    public boolean isAuthorized(HandshakeData handshakeData) {
+        // query 에서 token 파라미터 추출
+        String token = handshakeData.getSingleUrlParam("token");
+        if (token == null || token.isBlank()) {
+            return false;
+        }
+        return validateToken(token);
+    }
+
+    private boolean validateToken(String token) {
+        return secretKey.equals(token);
+    }
+}

--- a/src/main/java/app/xray/stock/stock_service/adapter/in/socket/SocketAuthorizationListener.java
+++ b/src/main/java/app/xray/stock/stock_service/adapter/in/socket/SocketAuthorizationListener.java
@@ -2,14 +2,30 @@ package app.xray.stock.stock_service.adapter.in.socket;
 
 import com.corundumstudio.socketio.AuthorizationListener;
 import com.corundumstudio.socketio.HandshakeData;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
 
 @Component
 public class SocketAuthorizationListener implements AuthorizationListener {
 
-    @Value("${socketio.secret-key}")
-    private String secretKey;
+    @Value("${jwt.secret}")
+    private String jwtSecret;
+
+    private Key key;
+
+    @PostConstruct
+    public void init() {
+        // secret 값에서 Key 객체 생성 (HMAC-SHA)
+        this.key = Keys.hmacShaKeyFor(jwtSecret.getBytes(StandardCharsets.UTF_8));
+    }
 
     @Override
     public boolean isAuthorized(HandshakeData handshakeData) {
@@ -22,6 +38,17 @@ public class SocketAuthorizationListener implements AuthorizationListener {
     }
 
     private boolean validateToken(String token) {
-        return secretKey.equals(token);
+        try {
+            // 1. 토큰 파싱 및 서명 검증 (이게 통과시 유효)
+            Jwts.parserBuilder()
+                    .setSigningKey(this.key)
+                    .build()
+                    .parseClaimsJws(token);
+            // 2. 여기서 추가적인 claim 검사도 가능 (예: 만료, issuer 등)
+            return true;
+        } catch (Exception e) {
+            // 파싱 실패 (유효하지 않은 토큰)
+            return false;
+        }
     }
 }

--- a/src/main/java/app/xray/stock/stock_service/common/config/SocketIOConfig.java
+++ b/src/main/java/app/xray/stock/stock_service/common/config/SocketIOConfig.java
@@ -1,11 +1,8 @@
 package app.xray.stock.stock_service.common.config;
 
+import app.xray.stock.stock_service.adapter.in.socket.SocketAuthorizationListener;
 import com.corundumstudio.socketio.SocketIOServer;
 import com.corundumstudio.socketio.Transport;
-import com.corundumstudio.socketio.protocol.JacksonJsonSupport;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.context.annotation.Bean;
@@ -21,11 +18,12 @@ public class SocketIOConfig {
     private Integer port;
 
     @Bean
-    public SocketIOServer socketIOServer() {
+    public SocketIOServer socketIOServer(SocketAuthorizationListener authorizationListener) {
         com.corundumstudio.socketio.Configuration config = new com.corundumstudio.socketio.Configuration();
         config.setHostname(host);
         config.setPort(port);
         config.setTransports(Transport.WEBSOCKET); // 강제 웹소켓 only
+        config.setAuthorizationListener(authorizationListener);
         return new SocketIOServer(config);
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,5 +37,5 @@ endpoint:
   stock-generator:
     base-url: http://localhost:8080/api/v1
 
-socketio:
-  secret-key: ${SOCKETIO_SECRET_KEY:6c9d9411-9727-47c4-9d76-64dcfb761083}
+jwt:
+  secret: ${JWT_SECRET:change-me-jwt-secret-aabbccddeeff11223344556677889900aabbccddeeff1122}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,3 +36,6 @@ server:
 endpoint:
   stock-generator:
     base-url: http://localhost:8080/api/v1
+
+socketio:
+  secret-key: ${SOCKETIO_SECRET_KEY:6c9d9411-9727-47c4-9d76-64dcfb761083}


### PR DESCRIPTION
## [Socket] 실시간 주식 트레이드 틱 정보 브로드캐스팅 구현 3 - JWT 인증처리 구현

### 주요 변경 사항

- **JWT 기반 소켓 인증 도입**
  - 클라이언트가 소켓 서버에 연결할 때, 반드시 쿼리 파라미터로 JWT 토큰(token)을 전달해야 함
  - 서버는 전달받은 JWT의 서명 및 유효성을 검증. 유효하지 않은 토큰이면 연결 거부
  - JWT 시크릿키는 환경변수/설정파일로 관리

- **코드 구조**
  - `SocketAuthorizationListener` 클래스 추가: `AuthorizationListener`를 구현하여 소켓 연결 전 JWT 인증 로직 처리
  - `SocketIOConfig`에서 AuthorizationListener를 소켓 서버에 주입하여 인증 미통과시 연결 불가
  - JWT 관련 라이브러리 의존성 추가(`build.gradle`)
  - `application.yml`에 jwt 시크릿 변수 추가

### 상호작용 및 인증 흐름

1. **클라이언트 연결 요청**
   - 클라이언트는 소켓 접속 시, 예를 들어 아래와 같이 요청:
     ```
     ws://<host>:<port>?token=<JWT>
     ```
2. **서버 인증 절차**
   - `SocketAuthorizationListener.isAuthorized(HandshakeData handshakeData)`에서 JWT 추출
   - JWT 서명 및 구조 유효성 검증 (만료, issuer 등 추가 검증 가능)
   - 검증 실패 시 소켓 연결 거절, 성공 시 정상 연결

3. **실패/성공 시 동작**
   - 올바른 JWT: 실시간 트레이드 틱 데이터 수신 가능
   - 잘못된/누락된 JWT: 소켓 연결 자체가 이루어지지 않음

### 테스트 및 검증 방법

- **정상 시나리오**
  1. JWT를 발급받아, 클라이언트에서 소켓 연결 요청 시 `token` 파라미터에 JWT 전달
  2. 정상적으로 소켓 연결됨을 확인, 실시간 데이터 브로드캐스팅 수신 가능

- **예외/실패 시나리오**
  1. `token` 파라미터가 없거나 빈 값일 때 소켓 연결이 거부되는지 확인
  2. 임의로 조작된/만료된 JWT로 요청 시 연결이 거부되는지 확인

- **자동화 테스트**
  - (예시) Mock 클라이언트로 정상/비정상 JWT를 각각 사용하여 소켓 연결 시도 후 성공/실패 여부 검증

### 변경 파일 요약

- `build.gradle` : JWT 라이브러리 의존성 추가
- `SocketAuthorizationListener.java` : 소켓 JWT 인증 리스너 구현 (신규)
- `SocketIOConfig.java` : 인증 리스너 소켓 서버에 주입
- `application.yml` : `jwt.secret` 환경변수 추가

### 추가 참고

- JWT claim 검증(만료, issuer 등)은 필요에 따라 `validateToken`에서 확장 가능
- 시크릿키는 반드시 안전하게 관리 필요
