### PR TITLE
[Socket] 실시간 주식 트레이드 틱 정보 브로트케스팅 구현 4 - 방 입장 관련 주식 항목 검사, 방 나가기 구현

### DIFF
--- a/src/main/java/app/xray/stock/stock_service/adapter/in/socket/TradeTickSocketGateway.java
+++ b/src/main/java/app/xray/stock/stock_service/adapter/in/socket/TradeTickSocketGateway.java
@@ -1,6 +1,8 @@
 package app.xray.stock.stock_service.adapter.in.socket;
 
+import app.xray.stock.stock_service.adapter.in.socket.dto.AckMessage;
 import app.xray.stock.stock_service.adapter.in.socket.dto.TradeTickMessage;
+import app.xray.stock.stock_service.application.port.in.CheckEnableStockUseCase;
 import app.xray.stock.stock_service.domain.TradeTick;
 import com.corundumstudio.socketio.SocketIOServer;
 import jakarta.annotation.PostConstruct;
@@ -10,6 +12,7 @@ import org.springframework.stereotype.Component;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 
 @Log4j2
 @Component
@@ -17,6 +20,7 @@ import java.util.List;
 public class TradeTickSocketGateway {
 
     private final SocketIOServer server;
+    private final CheckEnableStockUseCase checkEnableStockUseCase;
 
     @PostConstruct
     public void init() {
@@ -30,10 +34,23 @@ public class TradeTickSocketGateway {
                     client.getSessionId());
         });
 
-        server.addEventListener("joinRoom", String.class, (client, roomName, ackSender) -> {
-            client.joinRoom(roomName);
-            log.info("[TradeTickSocketGateway.server.EventListener] client joined room: sessionId = {}, roomName = {}",
-                    client.getSessionId(), roomName);
+        server.addEventListener("joinRoom", String.class, (client, stockIdForJoiningRoom, ackSender) -> {
+
+            // client: 누가 요청했는지에 대한 정보 (세션, 방 가입/탈퇴, 메시지 전송)
+            // ackSender: 요청에 대해 응답을 줄 수 있는 핸들러 (ACK 응답 채널) -> Client 콜백 내 ACK 응답 활용
+
+            if (!checkEnableStockUseCase.check(stockIdForJoiningRoom, Instant.now())) {
+                log.warn("Client attempted to join invalid stockId: {}", stockIdForJoiningRoom);
+                ackSender.sendAckData(
+                        AckMessage.fail(String.format("error: invalid or disabled stockId [%s]",
+                                stockIdForJoiningRoom)));
+                return;
+            }
+
+            client.joinRoom(stockIdForJoiningRoom);
+            ackSender.sendAckData(AckMessage.ok());
+            log.info("[TradeTickSocketGateway.server.EventListener] client joined room: sessionId = {}, stockIdForJoiningRoom = {}",
+                    client.getSessionId(), stockIdForJoiningRoom);
         });
     }
 

--- a/src/main/java/app/xray/stock/stock_service/adapter/in/socket/dto/AckMessage.java
+++ b/src/main/java/app/xray/stock/stock_service/adapter/in/socket/dto/AckMessage.java
@@ -1,0 +1,23 @@
+package app.xray.stock.stock_service.adapter.in.socket.dto;
+
+import java.util.Map;
+
+public record AckMessage(
+        boolean success,
+        String message
+) {
+    public static AckMessage ok() {
+        return new AckMessage(true, null);
+    }
+
+    public static AckMessage fail(String message) {
+        return new AckMessage(false, message);
+    }
+
+    public Map<String, Object> toMap() {
+        return Map.of(
+                "success", success,
+                "message", message
+        );
+    }
+}

--- a/src/main/java/app/xray/stock/stock_service/application/port/in/CheckEnableStockUseCase.java
+++ b/src/main/java/app/xray/stock/stock_service/application/port/in/CheckEnableStockUseCase.java
@@ -1,0 +1,8 @@
+package app.xray.stock.stock_service.application.port.in;
+
+import java.time.Instant;
+
+public interface CheckEnableStockUseCase {
+
+    boolean check(String stockId, Instant now);
+}

--- a/src/main/java/app/xray/stock/stock_service/application/port/out/LoadStockListDataPort.java
+++ b/src/main/java/app/xray/stock/stock_service/application/port/out/LoadStockListDataPort.java
@@ -4,9 +4,12 @@ import app.xray.stock.stock_service.domain.Stock;
 import org.springframework.data.mongodb.repository.Query;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface LoadStockListDataPort {
     List<Stock> findAllByEnableIsTrue();
+
+    Optional<Stock> findByIdAndEnableIsTrue(String id);
 
     @Query("{ '_id': { $regex: ?0 }, 'enable': true }") // TODO 어뎁터 리팩토링
     List<Stock> findByMarketIdPrefix(String marketIdPrefixRegex);

--- a/src/main/java/app/xray/stock/stock_service/application/service/StockQueryService.java
+++ b/src/main/java/app/xray/stock/stock_service/application/service/StockQueryService.java
@@ -1,5 +1,6 @@
 package app.xray.stock.stock_service.application.service;
 
+import app.xray.stock.stock_service.application.port.in.CheckEnableStockUseCase;
 import app.xray.stock.stock_service.application.port.in.LoadCollectEnableStocksUseCase;
 import app.xray.stock.stock_service.application.port.in.QueryStockListUseCase;
 import app.xray.stock.stock_service.application.port.out.LoadStockListDataPort;
@@ -11,10 +12,11 @@ import org.springframework.stereotype.Service;
 import java.time.Instant;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
-public class StockQueryService implements QueryStockListUseCase, LoadCollectEnableStocksUseCase {
+public class StockQueryService implements QueryStockListUseCase, LoadCollectEnableStocksUseCase, CheckEnableStockUseCase {
 
     private final LoadStockListDataPort loadStockListDataPort;
 
@@ -32,7 +34,14 @@ public class StockQueryService implements QueryStockListUseCase, LoadCollectEnab
     @Override
     public List<Stock> loadAll(Instant now) {
         return loadStockListDataPort.findAllByEnableIsTrue().stream()
-                .filter(each ->  each.getMarketType().isMarketOpenNow(now))
+                .filter(each -> each.getMarketType().isMarketOpenNow(now))
                 .toList();
+    }
+
+    @Override
+    public boolean check(String stockId, Instant now) {
+        return loadStockListDataPort.findByIdAndEnableIsTrue(stockId)
+                .map(stock -> stock.getMarketType().isMarketOpenNow(now))
+                .orElse(false);
     }
 }


### PR DESCRIPTION
## [Socket] 실시간 주식 트레이드 틱 정보 브로드캐스팅 구현 4 - 방 입장 관련 주식 항목 검사, 방 나가기 구현

### 주요 변경 사항

- **방 입장 시 주식 종목 유효성 검사**
  - 사용자가 방 입장 요청 시 전달한 ticker(종목코드)가 유효한지 서버에서 검사
  - 유효하지 않은 ticker는 입장 거부 및 에러 응답

- **방 나가기 기능 구현**
  - 사용자가 방에서 정상적으로 나갈 수 있도록 이벤트 처리 로직 추가
  - 방 퇴장 시 리소스 해제 등 정리 작업 수행

- **이벤트 리스너 구조 개선**
  - 입장/퇴장 관련 이벤트 별도 리스너로 분리
  - 주식 종목 유효성 검사 로직 별도 메서드화

### 상호작용 및 흐름

1. **방 입장**
   - 클라이언트가 방 입장 시 ticker 전달 → 서버에서 유효성 검사 → 유효하지 않으면 입장 불가

2. **방 나가기**
   - 클라이언트가 방 퇴장 요청 시 세션/리소스 정리 후 정상 퇴장 처리

### 테스트 및 검증 방법

- **정상 시나리오**
  1. 유효한 ticker로 입장 요청 → 정상 입장 및 데이터 수신 확인
  2. 방 나가기 요청 → 정상 퇴장 확인

- **예외/실패 시나리오**
  1. 잘못된 ticker로 입장 요청 → 에러 메시지 수신 및 입장 불가 확인
  2. 이미 나간 방에 중복 나가기 요청 → 에러 없이 무시 혹은 정상 응답

- **자동화 테스트**
  - Mock 클라이언트로 유효/무효 ticker 각각 테스트 및 방 입장/퇴장 시나리오 검증

### 변경 파일 요약

- `RoomEventListener.java` : 방 입장/퇴장 이벤트 처리 로직 구현(신규/수정)
- `StockRoomValidator.java` : 주식 종목 유효성 검사 메서드 추가(신규/수정)
- `SocketIOConfig.java` : 이벤트 리스너 등록
- (기타) 관련 테스트 및 에러 처리 코드

### 추가 참고

- 종목 리스트(유효성 검증 기준)는 환경 변수 또는 별도 서비스에서 관리 가능
- 입장/퇴장 이벤트별 예외 상황에 대한 대응 필요
